### PR TITLE
Fix "USE <keyspace>" so it returns `Set_keyspace` result

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -492,7 +492,7 @@ func (c *client) interceptSystemQuery(hdr *frame.Header, stmt interface{}) {
 			c.send(hdr, &message.ServerError{ErrorMessage: "Proxy unable to create new session for keyspace"})
 		} else {
 			c.keyspace = s.Keyspace
-			c.send(hdr, &message.VoidResult{})
+			c.send(hdr, &message.SetKeyspaceResult{Keyspace: s.Keyspace})
 		}
 	case *parser.ErrorSelectStatement:
 		c.send(hdr, &message.Invalid{ErrorMessage: s.Err.Error()})

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -230,6 +230,56 @@ func TestProxy_Unprepared(t *testing.T) {
 	assert.Equal(t, numNodes, count)
 }
 
+func TestProxy_UseKeyspace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	const clusterContactPoint = "127.0.0.1:8000"
+	const clusterPort = 8000
+
+	const proxyContactPoint = "127.0.0.1:9042"
+
+	cluster := proxycore.NewMockCluster(net.ParseIP("127.0.0.0"), clusterPort)
+	defer cluster.Shutdown()
+
+	err := cluster.Add(ctx, 1)
+	require.NoError(t, err)
+
+	proxy := NewProxy(ctx, Config{
+		Version:           primitive.ProtocolVersion4,
+		Resolver:          proxycore.NewResolverWithDefaultPort([]string{clusterContactPoint}, clusterPort),
+		ReconnectPolicy:   proxycore.NewReconnectPolicyWithDelays(200*time.Millisecond, time.Second),
+		NumConns:          2,
+		HeartBeatInterval: 30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	})
+
+	err = proxy.Listen(proxyContactPoint)
+	defer func(proxy *Proxy) {
+		_ = proxy.Shutdown()
+	}(proxy)
+	require.NoError(t, err)
+
+	go func() {
+		_ = proxy.Serve()
+	}()
+
+	cl, err := proxycore.ConnectClient(ctx, proxycore.NewEndpoint(proxyContactPoint), proxycore.ClientConnConfig{})
+	require.NoError(t, err)
+
+	version, err := cl.Handshake(ctx, primitive.ProtocolVersion4, nil)
+	require.NoError(t, err)
+	assert.Equal(t, primitive.ProtocolVersion4, version)
+
+	resp, err := cl.SendAndReceive(ctx, frame.NewFrame(version, 0, &message.Query{Query: "USE system"}))
+	require.NoError(t, err)
+
+	assert.Equal(t, primitive.OpCodeResult, resp.Header.OpCode)
+	res, ok := resp.Body.Message.(*message.SetKeyspaceResult)
+	require.True(t, ok, "expected set keyspace result")
+	assert.Equal(t, "system", res.Keyspace)
+}
+
 func testQueryHosts(ctx context.Context, cl *proxycore.ClientConn) (map[string]struct{}, error) {
 	hosts := make(map[string]struct{})
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
"USE keyspace" queries were returning a `Void` result instead of the proper `Set_keyspace` result.