### PR TITLE
Handle invalid column values when making a new endpoint

### DIFF
--- a/astra/endpoint.go
+++ b/astra/endpoint.go
@@ -109,12 +109,15 @@ func (r *astraResolver) NewEndpoint(row proxycore.Row) (proxycore.Endpoint, erro
 	if err != nil {
 		return nil, err
 	}
-	uuid := hostId.(primitive.UUID)
-	return &astraEndpoint{
-		addr:      sniProxyAddress,
-		key:       fmt.Sprintf("%s:%s", sniProxyAddress, &uuid),
-		tlsConfig: copyTLSConfig(r.bundle, uuid.String()),
-	}, nil
+	if uuid, ok := hostId.(primitive.UUID); !ok {
+		return nil, errors.New("ignoring host because its `host_id` is not set or is invalid")
+	} else {
+		return &astraEndpoint{
+			addr:      sniProxyAddress,
+			key:       fmt.Sprintf("%s:%s", sniProxyAddress, &uuid),
+			tlsConfig: copyTLSConfig(r.bundle, uuid.String()),
+		}, nil
+	}
 }
 
 func (a astraEndpoint) String() string {

--- a/proxycore/endpoint.go
+++ b/proxycore/endpoint.go
@@ -113,10 +113,17 @@ func (r *defaultEndpointResolver) NewEndpoint(row Row) (Endpoint, error) {
 		return nil, err
 	}
 
-	addr := rpcAddress.(net.IP)
+	var ok bool
+	var addr net.IP
+
+	if addr, ok = rpcAddress.(net.IP); !ok {
+		return nil, errors.New("ignoring host because its `rpc_address` is not set or is invalid")
+	}
 
 	if addr.Equal(net.IPv4zero) || addr.Equal(net.IPv6zero) {
-		addr = peer.(net.IP)
+		if addr, ok = peer.(net.IP); !ok {
+			return nil, errors.New("ignoring host because its `peer` is not set or is invalid")
+		}
 	}
 
 	return &defaultEndpoint{


### PR DESCRIPTION
Add code that protects against bad values in the `system.local` and
`system.peers` table columns when construct new endpoints.