### PR TITLE
Protocol v3 compatibility

### DIFF
--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -21,131 +21,95 @@ import (
 
 var (
 	SystemLocalColumns = []*message.ColumnMetadata{
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "key",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "rpc_address",
-			Type:     datatype.Inet,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "data_center",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "rack",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "tokens",
-			Type:     datatype.NewSetType(datatype.Varchar),
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "release_version",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "partitioner",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "cluster_name",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "cql_version",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "schema_version",
-			Type:     datatype.Uuid,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "native_protocol_version",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "local",
-			Name:     "host_id",
-			Type:     datatype.Uuid,
-		},
+		{Keyspace: "system", Table: "local", Name: "key", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "local", Name: "rpc_address", Type: datatype.Inet},
+		{Keyspace: "system", Table: "local", Name: "data_center", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "local", Name: "rack", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "local", Name: "tokens", Type: datatype.NewSetType(datatype.Varchar)},
+		{Keyspace: "system", Table: "local", Name: "release_version", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "local", Name: "partitioner", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "local", Name: "cluster_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "local", Name: "cql_version", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "local", Name: "schema_version", Type: datatype.Uuid},
+		{Keyspace: "system", Table: "local", Name: "native_protocol_version", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "local", Name: "host_id", Type: datatype.Uuid},
 	}
 
 	SystemPeersColumns = []*message.ColumnMetadata{
-		{
-			Keyspace: "system",
-			Table:    "peers",
-			Name:     "peer",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "peers",
-			Name:     "rpc_address",
-			Type:     datatype.Inet,
-		},
-		{
-			Keyspace: "system",
-			Table:    "peers",
-			Name:     "data_center",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "peers",
-			Name:     "rack",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "peers",
-			Name:     "tokens",
-			Type:     datatype.NewSetType(datatype.Varchar),
-		},
-		{
-			Keyspace: "system",
-			Table:    "peers",
-			Name:     "release_version",
-			Type:     datatype.Varchar,
-		},
-		{
-			Keyspace: "system",
-			Table:    "peers",
-			Name:     "schema_version",
-			Type:     datatype.Uuid,
-		},
-		{
-			Keyspace: "system",
-			Table:    "peers",
-			Name:     "host_id",
-			Type:     datatype.Uuid,
-		},
+		{Keyspace: "system", Table: "peers", Name: "peer", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "peers", Name: "rpc_address", Type: datatype.Inet},
+		{Keyspace: "system", Table: "peers", Name: "data_center", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "peers", Name: "rack", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "peers", Name: "tokens", Type: datatype.NewSetType(datatype.Varchar)},
+		{Keyspace: "system", Table: "peers", Name: "release_version", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "peers", Name: "schema_version", Type: datatype.Uuid},
+		{Keyspace: "system", Table: "peers", Name: "host_id", Type: datatype.Uuid},
+	}
+
+	SystemSchemaKeyspaces = []*message.ColumnMetadata{
+		{Keyspace: "system", Table: "schema_keyspaces", Name: "keyspace_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_keyspaces", Name: "durable_writes", Type: datatype.Boolean},
+		{Keyspace: "system", Table: "schema_keyspaces", Name: "strategy_class", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_keyspaces", Name: "strategy_options", Type: datatype.Varchar},
+	}
+
+	SystemSchemaColumnFamilies = []*message.ColumnMetadata{
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "keyspace_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "columnfamily_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "bloom_filter_fp_chance", Type: datatype.Double},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "caching", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "cf_id", Type: datatype.Uuid},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "comment", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "compaction_strategy_class", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "compaction_strategy_options", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "comparator", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "compression_parameters", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "default_time_to_live", Type: datatype.Int},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "default_validator", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "dropped_columns", Type: datatype.NewMapType(datatype.Varchar, datatype.Bigint)},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "gc_grace_seconds", Type: datatype.Int},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "is_dense", Type: datatype.Boolean},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "key_validator", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "local_read_repair_chance", Type: datatype.Double},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "max_compaction_threshold", Type: datatype.Int},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "max_index_interval", Type: datatype.Int},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "memtable_flush_period_in_ms", Type: datatype.Int},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "min_compaction_threshold", Type: datatype.Int},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "min_index_interval", Type: datatype.Int},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "read_repair_chance", Type: datatype.Double},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "speculative_retry", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "subcomparator", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columnfamilies", Name: "type", Type: datatype.Varchar},
+	}
+
+	SystemSchemaColumns = []*message.ColumnMetadata{
+		{Keyspace: "system", Table: "schema_columns", Name: "keyspace_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columns", Name: "columnfamily_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columns", Name: "column_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columns", Name: "component_index", Type: datatype.Int},
+		{Keyspace: "system", Table: "schema_columns", Name: "index_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columns", Name: "index_options", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columns", Name: "index_type", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columns", Name: "type", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_columns", Name: "validator", Type: datatype.Varchar},
+	}
+
+	SystemSchemaUsertypes = []*message.ColumnMetadata{
+		{Keyspace: "system", Table: "schema_usertypes", Name: "keyspace_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_usertypes", Name: "type_name", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "schema_usertypes", Name: "field_names", Type: datatype.NewListType(datatype.Varchar)},
+		{Keyspace: "system", Table: "schema_usertypes", Name: "field_types", Type: datatype.NewListType(datatype.Varchar)},
 	}
 )
+
+var SystemColumnsByName = map[string][]*message.ColumnMetadata{
+	"local":                 SystemLocalColumns,
+	"peers":                 SystemPeersColumns,
+	"schema_keyspaces":      SystemSchemaKeyspaces,
+	"schema_columnfamilies": SystemSchemaColumnFamilies,
+	"schema_columns":        SystemSchemaColumns,
+	"schema_usertypes":      SystemSchemaUsertypes,
+}
 
 func FindColumnMetadata(columns []*message.ColumnMetadata, name string) *message.ColumnMetadata {
 	for _, column := range columns {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"strings"
 
-	parser "github.com/datastax/cql-proxy/proxycore/antlr"
 	"github.com/antlr/antlr4/runtime/Go/antlr"
+	parser "github.com/datastax/cql-proxy/proxycore/antlr"
 	"github.com/datastax/go-cassandra-native-protocol/datatype"
 	"github.com/datastax/go-cassandra-native-protocol/message"
 )
@@ -29,7 +29,7 @@ const (
 	CountValueName = "count(*)"
 )
 
-var systemTables = []string{"local", "peers", "peers_v2"}
+var systemTables = []string{"local", "peers", "peers_v2", "schema_keyspaces", "schema_columnfamilies", "schema_columns", "schema_usertypes"}
 
 type AliasSelector struct {
 	Selector interface{}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -95,6 +95,12 @@ func (p *Proxy) OnEvent(event interface{}) {
 }
 
 func NewProxy(ctx context.Context, config Config) *Proxy {
+	if config.Version == 0 {
+		config.Version = primitive.ProtocolVersion4
+	}
+	if config.MaxVersion == 0 {
+		config.MaxVersion = primitive.ProtocolVersion4
+	}
 	return &Proxy{
 		ctx:    ctx,
 		config: config,


### PR DESCRIPTION
This supports drivers that use CQL protocol v3. Multiple protocol
versions are supported within a single proxy instance and are created
on-the-fly.

Also, the proxy intercepts queries to legacy schema tables that lived
under the `system` keyspace (e.g. `system.schema_keyspaces`). The
current implementation returns an empty result set. In the future, this
could query the modern tables under `system_schema` and convert them the
legacy results.

Tested using the legacy java-driver version `2.1.10.3`.