### PR TITLE
Add support for detecting idempotent mutation queries

### DIFF
--- a/parser/bench/bench_parser.go
+++ b/parser/bench/bench_parser.go
@@ -1,0 +1,204 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/datastax/cql-proxy/parser"
+)
+
+var queries = []struct {
+	query      string
+	handled    bool
+	idempotent bool
+}{
+	{"\n   SELECT * FROM\nsystem.local", true, true},
+	{"\tSELECT key FROM system.local", true, true},
+	{"SELECT * FROM system.peers", true, true},
+	{"SELECT * FROM system.peers_v2", true, true},
+	{"SELECT * FROM local", true, true},
+	{"SELECT * FROM peers", true, true},
+	{"SELECT * FROM \"peers\"", true, true},
+	{"SELECT * FROM \"local\"", true, true},
+	{"SELECT * FROM \"system\".\"local\"", true, true},
+	{"SELECT a, b, c FROM peers", true, true},
+	{"USE PortfolioDemo;", true, false},
+	{"USE \"Excalibur\";", true, false},
+	{"SELECT event_id, \n  dateOf(created_at) AS creation_date,\n  blobAsText(content) AS content \n  FROM timeline;", false, true},
+	{"SELECT COUNT(*) \nFROM system.IndexInfo;", false, true},
+	{"SELECT lastname \nFROM cycling.cyclist_name \nLIMIT 50000;", false, true},
+	{"SELECT id, lastname, teams \nFROM cycling.cyclist_career_teams \nWHERE id=5b6962dd-3f90-4c93-8f61-eabfa4a803e2;", false, true},
+	{"SELECT sum(race_points) \nFROM cycling.cyclist_points \nWHERE id=e3b19ec4-774a-4d1c-9e5a-decec1e30aac \n      AND race_points > 7;", false, true},
+	{"SELECT first_name, last_name \nFROM emp \nWHERE empID IN (105, 107, 104);", false, true},
+	{"SELECT * \nFROM parts \nWHERE part_type='alloy' AND part_name='hubcap' \nAND part_num=1249 AND part_year IN ('2010', '2015');", false, true},
+	{"SELECT * \nFROM parts \nWHERE part_num=123456 AND part_year IN ('2010', '2015') \nALLOW FILTERING;", false, true},
+	{"SELECT album, tags \nFROM playlists \nWHERE tags CONTAINS 'blues';", false, true},
+	{"SELECT * \nFROM playlists \nWHERE venue \nCONTAINS 'The Fillmore';", false, true},
+	{"SELECT * \nFROM playlists \nWHERE venue CONTAINS KEY '2014-09-22 22:00:00-0700';", false, true},
+	{"SELECT * \nFROM cycling.birthday_list \nWHERE blist['age'] = '23';", false, true},
+	{"SELECT * \nFROM cycling.race_starts \nWHERE rnumbers = [39,7,14];", false, true},
+	{"SELECT * FROM ruling_stewards\nWHERE king = 'Brego'\n  AND reign_start >= 2450\n  AND reign_start < 2500 \nALLOW FILTERING;", false, true},
+	{"Select * \nFROM ruling_stewards\nWHERE king = 'none'\n  AND reign_start >= 1500\n  AND reign_start < 3000 \nLIMIT 10 \nALLOW FILTERING;", false, true},
+	{"SELECT * \nFROM ruling_stewards \nWHERE (steward_name, king) = ('Boromir', 'Brego');", false, true},
+	{"SELECT * FROM playlists \nWHERE id = 62c36092-82a1-3a00-93d1-46196ee77204\nORDER BY song_order DESC \nLIMIT 50;", false, true},
+	{"SELECT album, title \nFROM playlists \nWHERE artist = 'Fu Manchu';", false, true},
+	{"SELECT * \nFROM cycling.last_3_days \nWHERE TOKEN(year) < TOKEN('2015-05-26') \n  AND year IN ('2015-05-24','2015-05-25');", false, true},
+	{"SELECT COUNT(lastname) \nFROM cycling.cyclist_name;", false, true},
+	{"SELECT COUNT(*) \nFROM users;", false, true},
+	{"SELECT name, max(points), COUNT(*) \nFROM users;", false, true},
+	{"SELECT MAX(points) \nFROM cycling.cyclist_category;", false, true},
+	{"SELECT category, MIN(points) \nFROM cycling.cyclist_category \nWHERE category = 'GC';", false, true},
+	{"SELECT WRITETIME (first_name) \nFROM users \nWHERE last_name = 'Jones';", false, true},
+	{"INSERT INTO cycling.calendar (race_id, race_name, race_start_date, race_end_date) \nVALUES (200, 'placeholder', '2015-05-27', '2015-05-27') \nUSING TTL;", false, true},
+	{"UPDATE cycling.calendar \nUSING TTL 300 \nSET race_name = 'dummy' \nWHERE race_id = 200 \n  AND race_start_date = '2015-05-27' \n  AND race_end_date = '2015-05-27';", false, true},
+	{"SELECT TTL(race_name) \nFROM cycling.calendar \nWHERE race_id=200;", false, true},
+	{"DELETE firstname, lastname FROM cycling.cyclist_name \nWHERE id = e7ae5cf3-d358-4d99-b900-85902fda9bb0;", false, true},
+	{"DELETE FROM cycling.cyclist_name \nWHERE id=e7ae5cf3-d358-4d99-b900-85902fda9bb0 IF EXISTS;", false, false},
+	{"DELETE FROM cycling.cyclist_name \nWHERE id =e7ae5cf3-d358-4d99-b900-85902fda9bb0 \nif firstname='Alex' and lastname='Smith';", false, false},
+	{"DELETE id FROM cyclist_id \nWHERE lastname = 'WELTEN' and firstname = 'Bram' \nIF EXISTS;", false, false},
+	{"DELETE id FROM cyclist_id \nWHERE lastname = 'WELTEN' AND firstname = 'Bram' \nIF age = 2000;", false, false},
+	{"DELETE firstname, lastname\n  FROM cycling.cyclist_name\n  USING TIMESTAMP 1318452291034\n  WHERE lastname = 'VOS';", false, true},
+	{"DELETE FROM cycling.cyclist_name \nWHERE id = 6ab09bec-e68e-48d9-a5f8-97e6fb4c9b47;", false, true},
+	{"DELETE FROM cycling.cyclist_name \nWHERE firstname IN ('Alex', 'Marianne');", false, true},
+	{"DELETE sponsorship ['sponsor_name'] FROM cycling.races \nWHERE race_name = 'Criterium du Dauphine';", false, true},
+	{"DELETE categories[3] FROM cycling.cyclist_history \nWHERE lastname = 'TIRALONGO';", false, false},
+	{"DELETE sponsorship FROM cycling.races \nWHERE race_name = 'Criterium du Dauphine';", false, true},
+	{"UPDATE cycling.cyclist_name\nSET comments ='Rides hard, gets along with others, a real winner'\nWHERE id = fb372533-eb95-4bb4-8685-6ef61e994caa IF EXISTS;", false, false},
+	{"UPDATE users\n  SET state = 'TX'\n  WHERE user_uuid\n  IN (88b8fd18-b1ed-4e96-bf79-4280797cba80,\n    06a8913c-c0d6-477c-937d-6c1b69a95d43,\n    bc108776-7cb5-477f-917d-869c12dfffa8);", false, true},
+	{"UPDATE cycling.cyclists\n  SET firstname = 'Marianne',\n  lastname = 'VOS'\n  WHERE id = 88b8fd18-b1ed-4e96-bf79-4280797cba80;", false, true},
+	{"UPDATE excelsior.clicks USING TTL 432000\n  SET user_name = 'bob'\n  WHERE userid=cfd66ccc-d857-4e90-b1e5-df98a3d40cd6 AND\n    url='http://google.com';", false, true},
+	{"UPDATE cycling.popular_count SET popularity = popularity + 2 WHERE id = 6ab09bec-e68e-48d9-a5f8-97e6fb4c9b47;", false, false},
+	{"UPDATE cycling.cyclists\nSET firstname = 'Anna', lastname = 'VAN DER BREGGEN' WHERE id = e7cd5752-bc0d-4157-a80f-7523add8dbcd;", false, true},
+	{"UPDATE cycling.upcoming_calendar \nSET events = ['Criterium du Dauphine','Tour de Suisse'];", false, true},
+	{"UPDATE cycling.upcoming_calendar \nSET events = ['Tour de France'] + events WHERE year=2015 AND month=06;", false, false},
+	{"UPDATE cycling.upcoming_calendar \nSET events[4] = 'Tour de France' WHERE year=2016 AND month=07;", false, true},
+	{"UPDATE cycling.upcoming_calendar \nSET events = events - ['Criterium du Dauphine'] WHERE year=2016 AND month=07;", false, false},
+	{"UPDATE cycling.cyclist_career_teams\nSET teams = teams + {'Team DSB - Ballast Nedam'} WHERE id=5b6962dd-3f90-4c93-8f61-eabfa4a803e2;", false, true},
+	{"UPDATE cycling.cyclist_career_teams\nSET teams = teams - {'DSB Bank Nederland bloeit'} WHERE id=5b6962dd-3f90-4c93-8f61-eabfa4a803e2;", false, true},
+	{"UPDATE cycling.cyclist_career_teams\nSET teams = {} WHERE id=5b6962dd-3f90-4c93-8f61-eabfa4a803e2;", false, true},
+	{"UPDATE cycling.upcoming_calendar \nSET description = description + {'Criterium du Dauphine' : 'Easy race'} WHERE year = 2015;\n", false, true},
+	{"UPDATE cycling.upcoming_calendar \nSET events[2] = 'Vuelta Ciclista a Venezuela' WHERE year = 2016 AND month = 06;", false, true},
+	{"UPDATE cycling.upcoming_calendar USING TTL 1234\nSET events[2] = 'Vuelta Ciclista a Venezuela' WHERE year = 2016 AND month = 06;", false, true},
+	{"UPDATE cycling.upcoming_calendar \nSET description = description + {'Criterium du Dauphine' : 'Easy race', 'Tour du Suisse' : 'Hard uphill race'}\nWHERE year = 2015 AND month = 6;", false, true},
+	{"UPDATE cycling.upcoming_calendar \nSET description = \n{'Criterium du Dauphine' : 'Easy race', \n 'Tour du Suisse' : 'Hard uphill race'} \nWHERE year = 2015 AND month = 6;", false, true},
+	{"UPDATE cycling.upcoming_calendar \nSET description = description + { 'Tour de France' : 'Very competitive'} \nWHERE year = 2015 AND month = 6;", false, true},
+	{"UPDATE cycling.upcoming_calendar \nSET description = \n{'Criterium du Dauphine' : 'Easy race', \n 'Tour du Suisse' : 'Hard uphill race',\n 'Tour de France' : 'Very competitive'} \nWHERE year = 2015 AND month = 6;", false, true},
+	{"UPDATE cycling.cyclist_id SET age = 28 WHERE lastname = 'WELTEN' and firstname = 'Bram' IF EXISTS;", false, false},
+	{"UPDATE cyclist_id SET id = 15a116fc-b833-4da6-ab9a-4a3775750239 where lastname = 'WELTEN' and firstname = 'Bram' IF age = 18;", false, false},
+	{"BEGIN BATCH\n     INSERT INTO mytable (a, b, d) values (7, 7, 'a')\n     UPDATE mytable SET s = 1 WHERE a = 1 IF s = NULL;\nAPPLY BATCH", false, false},
+	{"BEGIN BATCH\n     INSERT INTO mytable (a, b, d) values (7, 7, 'a')\n     UPDATE mytable SET s = 7 WHERE a = 7 IF s = NULL;\nAPPLY BATCH", false, false},
+	{"INSERT INTO cycling.cyclist_name (id, lastname, firstname)\n  VALUES (6ab09bec-e68e-48d9-a5f8-97e6fb4c9b47, 'KRUIKSWIJK','Steven')\n  USING TTL 86400 AND TIMESTAMP 123456789;", false, true},
+	{"INSERT INTO cycling.cyclist_categories (id,lastname,categories)\n  VALUES(\n    '6ab09bec-e68e-48d9-a5f8-97e6fb4c9b47', \n    'KRUIJSWIJK', \n    {'GC', 'Time-trial', 'Sprint'});", false, true},
+	{"INSERT INTO cycling.cyclist_teams (id,lastname,teams)\n  VALUES(\n    5b6962dd-3f90-4c93-8f61-eabfa4a803e2, \n    'VOS', \n    { 2015 : 'Rabobank-Liv Woman Cycling Team', \n      2014 : 'Rabobank-Liv Woman Cycling Team' });", false, true},
+	{"INSERT INTO cycling.cyclist_name (id, lastname, firstname) \n   VALUES (c4b65263-fe58-4846-83e8-f0e1c13d518f, 'RATTO', 'Rissella') \nIF NOT EXISTS; ", false, false},
+	{"BEGIN BATCH USING TIMESTAMP 1481124356754405\nINSERT INTO cycling.cyclist_expenses \n   (cyclist_name, expense_id, amount, description, paid) \n   VALUES ('Vera ADRIAN', 2, 13.44, 'Lunch', true);\nINSERT INTO cycling.cyclist_expenses \n   (cyclist_name, expense_id, amount, description, paid) \n   VALUES ('Vera ADRIAN', 3, 25.00, 'Dinner', true);\nAPPLY BATCH;", false, false},
+	{"SELECT cyclist_name, expense_id,\n        amount, WRITETIME(amount),\n        description, WRITETIME(description),\n        paid,WRITETIME(paid)\n   FROM cycling.cyclist_expenses\nWHERE cyclist_name = 'Vera ADRIAN';", false, true},
+	{"BEGIN BATCH\n  INSERT INTO purchases (user, balance) VALUES ('user1', -8) IF NOT EXISTS;\n  INSERT INTO purchases (user, expense_id, amount, description, paid)\n    VALUES ('user1', 1, 8, 'burrito', false);\nAPPLY BATCH;", false, false},
+	{"BEGIN BATCH\n  UPDATE purchases SET balance = -208 WHERE user='user1' IF balance = -8;\n  INSERT INTO purchases (user, expense_id, amount, description, paid)\n    VALUES ('user1', 2, 200, 'hotel room', false);\nAPPLY BATCH;", false, false},
+	{"BEGIN COUNTER BATCH\n  UPDATE UserActionCounts SET total = total + 2 WHERE keyalias = 523;\n  UPDATE AdminActionCounts SET total = total + 2 WHERE keyalias = 701;\nAPPLY BATCH;", false, false},
+	{"INSERT INTO cycling.rank_by_year_and_name (race_year, race_name, cyclist_name, rank) \n   VALUES (2015, 'Tour of Japan - Stage 4 - Minami > Shinshu', 'Benjamin PRADES', 1);", false, true},
+	{"INSERT INTO cycling.rank_by_year_and_name (race_year, race_name, cyclist_name, rank) \n   VALUES (2015, 'Tour of Japan - Stage 4 - Minami > Shinshu', 'Adam PHELAN', 2);", false, true},
+	{"INSERT INTO cycling.rank_by_year_and_name (race_year, race_name, cyclist_name, rank) \n   VALUES (2015, 'Tour of Japan - Stage 4 - Minami > Shinshu', 'Thomas LEBAS', 3);", false, true},
+	{"INSERT INTO cycling.rank_by_year_and_name (race_year, race_name, cyclist_name, rank) \n   VALUES (2015, 'Giro d''Italia - Stage 11 - Forli > Imola', 'Ilnur ZAKARIN', 1);", false, true},
+	{"INSERT INTO cycling.rank_by_year_and_name (race_year, race_name, cyclist_name, rank) \n   VALUES (2015, 'Giro d''Italia - Stage 11 - Forli > Imola', 'Carlos BETANCUR', 2);", false, true},
+	{"INSERT INTO cycling.rank_by_year_and_name (race_year, race_name, cyclist_name, rank) \n   VALUES (2014, '4th Tour of Beijing', 'Phillippe GILBERT', 1);", false, true},
+	{"INSERT INTO cycling.rank_by_year_and_name (race_year, race_name, cyclist_name, rank)  \n   VALUES (2014, '4th Tour of Beijing', 'Daniel MARTIN', 2);", false, true},
+	{"INSERT INTO cycling.rank_by_year_and_name (race_year, race_name, cyclist_name, rank)  \n   VALUES (2014, '4th Tour of Beijing', 'Johan Esteban CHAVES', 3);", false, true},
+	{"SELECT * FROM cycling.cyclist_category;", false, true},
+	{"SELECT * FROM cycling.cyclist_category WHERE category = 'SPRINT';", false, true},
+	{"SELECT category, points, lastname FROM cycling.cyclist_category;", false, true},
+	{"SELECT * From cycling.cyclist_name LIMIT 3;", false, true},
+	{"SELECT * FROM cycling.cyclist_cat_pts WHERE category = 'GC' ORDER BY points ASC;", false, true},
+	{"SELECT race_name, point_id, lat_long AS CITY_LATITUDE_LONGITUDE FROM cycling.route;", false, true},
+	{"select json name, checkin_id, timestamp from checkin;", false, true},
+	{"select name, checkin_id, toJson(timestamp) from checkin;", false, true},
+	{"INSERT INTO cycling.cyclist_category JSON '{\n  \"category\" : \"GC\", false, false }, \n  \"points\" : 780, \n  \"id\" : \"829aa84a-4bba-411f-a4fb-38167a987cda\", false, false },\n  \"lastname\" : \"SUTHERLAND\" }';", false, true},
+	{"INSERT INTO cycling.cyclist_category JSON '{\n  \"category\" : \"Sprint\", false, false }, \n  \"points\" : 700, \n  \"id\" : \"829aa84a-4bba-411f-a4fb-38167a987cda\"\n}';", false, true},
+	{"INSERT INTO cycling.cyclist_stats (id, lastname, basics) VALUES (\n  e7ae5cf3-d358-4d99-b900-85902fda9bb0, \n  'FRAME', \n  { birthday : '1993-06-18', nationality : 'New Zealand', weight : null, height : null }\n);", false, true},
+	{"INSERT INTO cycling.cyclist_races (id, lastname, firstname, races) VALUES (\n  5b6962dd-3f90-4c93-8f61-eabfa4a803e2,\n  'VOS',\n  'Marianne',\n  [{ race_title : 'Rabobank 7-Dorpenomloop Aalburg',race_date : '2015-05-09',race_time : '02:58:33' },\n  { race_title : 'Ronde van Gelderland',race_date : '2015-04-19',race_time : '03:22:23' }]\n);", false, true},
+	{"INSERT INTO cycling.route (race_id, race_name, point_id, lat_long) VALUES (500, '47th Tour du Pays de Vaud', 2, ('Champagne', (46.833, 6.65)));", false, true},
+	{"INSERT INTO cycling.nation_rank (nation, info) VALUES ('Spain', (1,'Alejandro VALVERDE' , 9054));", false, true},
+	{"INSERT INTO cycling.popular (rank, cinfo) VALUES (4, ('Italy', 'Fabio ARU', 163));", false, true},
+	{"INSERT INTO t (k, s, i) VALUES ('k', 'I''m shared', 0);", false, true},
+	{"INSERT INTO t (k, s, i) VALUES ('k', 'I''m still shared', 1);", false, true},
+	{"SELECT * FROM t;", false, true},
+	{"BEGIN BATCH\n  INSERT INTO cycling.cyclist_expenses (cyclist_name, balance) VALUES ('Vera ADRIAN', 0) IF NOT EXISTS;\n  INSERT INTO cycling.cyclist_expenses (cyclist_name, expense_id, amount, description, paid) VALUES ('Vera ADRIAN', 1, 7.95, 'Breakfast', false);\n  APPLY BATCH;", false, false},
+	{"UPDATE cycling.cyclist_expenses SET balance = -7.95 WHERE cyclist_name = 'Vera ADRIAN' IF balance = 0;", false, false},
+}
+
+var result int
+
+func benchmarkIsQueryHandled(b *testing.B) {
+	var r int
+	id := parser.IdentifierFromString("system")
+	for n := 0; n < b.N; n++ {
+		for _, q := range queries {
+			handled, _, err := parser.IsQueryHandled(id, q.query)
+			if q.handled != handled {
+				r++
+				log.Panicf("expected query didn't match handled (expected: %v, actual: %v) for query \"%s\"", q.handled, handled, q.query)
+			}
+			if err != nil {
+				log.Panicf("unexpected error \"%v\" parsing query \"%s\"", err, q.query)
+			}
+		}
+	}
+	result = r
+}
+
+func benchmarkIsQueryIdempotent(b *testing.B) {
+	var r int
+	for n := 0; n < b.N; n++ {
+		for _, q := range queries {
+			idempotent, err := parser.IsQueryIdempotent(q.query)
+			if q.idempotent != idempotent {
+				r++
+				log.Panicf("expected query didn't match idempotent (expected: %v, actual: %v) for query \"%s\"", q.idempotent, idempotent, q.query)
+			}
+			if err != nil {
+				log.Panicf("unexpected error \"%v\" parsing query \"%s\"", err, q.query)
+			}
+		}
+	}
+	result = r
+}
+
+func main() {
+	numBytes := 0
+	for _, q := range queries {
+		numBytes += len(q.query)
+	}
+
+	rand.Seed(42)
+	rand.Shuffle(len(queries), func(i, j int) { queries[i], queries[j] = queries[j], queries[i] })
+
+	mb := float64(1024 * 1024)
+
+	var r testing.BenchmarkResult
+	var seconds float64
+
+	r = testing.Benchmark(benchmarkIsQueryHandled)
+	seconds = float64(r.T) / float64(time.Second) / float64(r.N)
+	fmt.Printf("parser.IsQueryHandled(): %d ns/op %f mib/s\n", int(r.T)/r.N, float64(numBytes)/mb/seconds)
+
+	r = testing.Benchmark(benchmarkIsQueryIdempotent)
+	seconds = float64(r.T) / float64(time.Second) / float64(r.N)
+	fmt.Printf("parser.IsQueryIdempotent(): %d ns/op %f mib/s\n", int(r.T)/r.N, float64(numBytes)/mb/seconds)
+}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -92,27 +92,33 @@ type lexer struct {
 	id       string
 }
 
+// initialize/reset lexer with data string to lex
 func (l *lexer) init(data string) {
 	l.p, l.pe = 0, len(data)
 	l.data = data
 }
 
+// mark the current lexer position
 func (l *lexer) mark() {
 	l.m = l.p
 }
 
+// rewind position to the the previously marked position
 func (l *lexer) rewind() {
 	l.p = l.m
 }
 
+// get the value of an identifier if that's the current token; otherwise, it's undefined
 func (l *lexer) identifier() Identifier {
 	return IdentifierFromString(l.id)
 }
 
+// get the value of an identifier as a string if that's the current token; otherwise, it's undefined
 func (l *lexer) identifierStr() string {
 	return l.id
 }
 
+// move to the next token
 func (l *lexer) next() token {
 	data := l.data
 	p, pe, eof := l.p, l.pe, l.pe
@@ -124,7 +130,7 @@ func (l *lexer) next() token {
 		return tkEOF
 	}
 
-//line lexer.go:134
+//line lexer.go:140
 	{
 		cs = lex_start
 		ts = 0
@@ -132,7 +138,7 @@ func (l *lexer) next() token {
 		act = 0
 	}
 
-//line lexer.go:142
+//line lexer.go:148
 	{
 		if p == pe {
 			goto _test_eof
@@ -809,7 +815,7 @@ func (l *lexer) next() token {
 					goto _out
 				}
 			}
-		case 44:
+		case 45:
 			{
 				p = (te) - 1
 				tk = tkStringLiteral
@@ -819,7 +825,7 @@ func (l *lexer) next() token {
 					goto _out
 				}
 			}
-		case 45:
+		case 46:
 			{
 				p = (te) - 1
 				tk = tkInteger
@@ -829,7 +835,7 @@ func (l *lexer) next() token {
 					goto _out
 				}
 			}
-		case 46:
+		case 47:
 			{
 				p = (te) - 1
 				tk = tkFloat
@@ -839,7 +845,7 @@ func (l *lexer) next() token {
 					goto _out
 				}
 			}
-		case 48:
+		case 49:
 			{
 				p = (te) - 1
 				tk = tkDuration
@@ -849,7 +855,7 @@ func (l *lexer) next() token {
 					goto _out
 				}
 			}
-		case 50:
+		case 51:
 			{
 				p = (te) - 1
 				tk = tkIdentifier
@@ -860,7 +866,7 @@ func (l *lexer) next() token {
 					goto _out
 				}
 			}
-		case 53:
+		case 54:
 			{
 				p = (te) - 1
 				tk = tkInvalid
@@ -874,7 +880,7 @@ func (l *lexer) next() token {
 
 		goto st90
 	tr2:
-//line lexer.rl:190
+//line lexer.rl:197
 		te = p + 1
 		{
 			tk = tkIdentifier
@@ -887,7 +893,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr11:
-//line lexer.rl:188
+//line lexer.rl:195
 		p = (te) - 1
 		{
 			tk = tkDuration
@@ -899,7 +905,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr17:
-//line lexer.rl:179
+//line lexer.rl:185
 		p = (te) - 1
 		{
 			tk = tkSub
@@ -911,7 +917,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr24:
-//line lexer.rl:183
+//line lexer.rl:189
 		te = p + 1
 		{
 			tk = tkInfinity
@@ -923,7 +929,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr26:
-//line lexer.rl:182
+//line lexer.rl:188
 		te = p + 1
 		{
 			tk = tkNan
@@ -935,7 +941,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr30:
-//line lexer.rl:188
+//line lexer.rl:195
 		te = p + 1
 		{
 			tk = tkDuration
@@ -947,7 +953,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr82:
-//line lexer.rl:189
+//line lexer.rl:196
 		te = p + 1
 		{
 			tk = tkUuid
@@ -959,7 +965,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr84:
-//line lexer.rl:185
+//line lexer.rl:192
 		p = (te) - 1
 		{
 			tk = tkInteger
@@ -971,7 +977,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr109:
-//line lexer.rl:193
+//line lexer.rl:200
 		te = p + 1
 		{
 			tk = tkInvalid
@@ -983,19 +989,19 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr110:
-//line lexer.rl:192
+//line lexer.rl:199
 		te = p + 1
 		{ /* Skip */
 		}
 		goto st90
 	tr111:
-//line lexer.rl:191
+//line lexer.rl:198
 		te = p + 1
 		{ /* Skip */
 		}
 		goto st90
 	tr117:
-//line lexer.rl:166
+//line lexer.rl:172
 		te = p + 1
 		{
 			tk = tkLparen
@@ -1007,7 +1013,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr118:
-//line lexer.rl:167
+//line lexer.rl:173
 		te = p + 1
 		{
 			tk = tkRparen
@@ -1019,7 +1025,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr119:
-//line lexer.rl:161
+//line lexer.rl:167
 		te = p + 1
 		{
 			tk = tkStar
@@ -1031,7 +1037,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr121:
-//line lexer.rl:162
+//line lexer.rl:168
 		te = p + 1
 		{
 			tk = tkComma
@@ -1043,7 +1049,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr123:
-//line lexer.rl:163
+//line lexer.rl:169
 		te = p + 1
 		{
 			tk = tkDot
@@ -1055,7 +1061,7 @@ func (l *lexer) next() token {
 		}
 		goto st90
 	tr126:
-//line lexer.rl:164
+//line lexer.rl:170
 		te = p + 1
 		{
 			tk = tkColon
@@ -1066,8 +1072,20 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr128:
-//line lexer.rl:172
+	tr127:
+//line lexer.rl:190
+		te = p + 1
+		{
+			tk = tkEOF
+			{
+				p++
+				cs = 90
+				goto _out
+			}
+		}
+		goto st90
+	tr129:
+//line lexer.rl:178
 		te = p + 1
 		{
 			tk = tkEqual
@@ -1078,8 +1096,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr130:
-//line lexer.rl:165
+	tr131:
+//line lexer.rl:171
 		te = p + 1
 		{
 			tk = tkQMark
@@ -1090,8 +1108,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr144:
-//line lexer.rl:168
+	tr145:
+//line lexer.rl:174
 		te = p + 1
 		{
 			tk = tkLsquare
@@ -1102,8 +1120,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr145:
-//line lexer.rl:169
+	tr146:
+//line lexer.rl:175
 		te = p + 1
 		{
 			tk = tkRsquare
@@ -1114,8 +1132,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr146:
-//line lexer.rl:170
+	tr147:
+//line lexer.rl:176
 		te = p + 1
 		{
 			tk = tkLcurly
@@ -1126,8 +1144,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr147:
-//line lexer.rl:171
+	tr148:
+//line lexer.rl:177
 		te = p + 1
 		{
 			tk = tkRcurly
@@ -1138,8 +1156,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr148:
-//line lexer.rl:193
+	tr149:
+//line lexer.rl:200
 		te = p
 		p--
 		{
@@ -1151,8 +1169,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr149:
-//line lexer.rl:177
+	tr150:
+//line lexer.rl:183
 		te = p + 1
 		{
 			tk = tkNotEqual
@@ -1163,8 +1181,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr150:
-//line lexer.rl:184
+	tr151:
+//line lexer.rl:191
 		te = p
 		p--
 		{
@@ -1176,8 +1194,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr151:
-//line lexer.rl:178
+	tr152:
+//line lexer.rl:184
 		te = p
 		p--
 		{
@@ -1189,8 +1207,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr152:
-//line lexer.rl:180
+	tr153:
+//line lexer.rl:186
 		te = p + 1
 		{
 			tk = tkAddEqual
@@ -1201,8 +1219,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr153:
-//line lexer.rl:179
+	tr154:
+//line lexer.rl:185
 		te = p
 		p--
 		{
@@ -1214,8 +1232,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr155:
-//line lexer.rl:181
+	tr156:
+//line lexer.rl:187
 		te = p + 1
 		{
 			tk = tkSubEqual
@@ -1226,8 +1244,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr159:
-//line lexer.rl:185
+	tr160:
+//line lexer.rl:192
 		te = p
 		p--
 		{
@@ -1239,8 +1257,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr162:
-//line lexer.rl:186
+	tr163:
+//line lexer.rl:193
 		te = p
 		p--
 		{
@@ -1252,8 +1270,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr163:
-//line lexer.rl:188
+	tr164:
+//line lexer.rl:195
 		te = p
 		p--
 		{
@@ -1265,8 +1283,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr188:
-//line lexer.rl:187
+	tr189:
+//line lexer.rl:194
 		te = p
 		p--
 		{
@@ -1278,8 +1296,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr189:
-//line lexer.rl:175
+	tr190:
+//line lexer.rl:181
 		te = p
 		p--
 		{
@@ -1291,8 +1309,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr190:
-//line lexer.rl:173
+	tr191:
+//line lexer.rl:179
 		te = p + 1
 		{
 			tk = tkLtEqual
@@ -1303,8 +1321,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr191:
-//line lexer.rl:176
+	tr192:
+//line lexer.rl:182
 		te = p
 		p--
 		{
@@ -1316,8 +1334,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr192:
-//line lexer.rl:174
+	tr193:
+//line lexer.rl:180
 		te = p + 1
 		{
 			tk = tkGtEqual
@@ -1328,8 +1346,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr193:
-//line lexer.rl:190
+	tr194:
+//line lexer.rl:197
 		te = p
 		p--
 		{
@@ -1342,8 +1360,8 @@ func (l *lexer) next() token {
 			}
 		}
 		goto st90
-	tr230:
-//line lexer.rl:156
+	tr231:
+//line lexer.rl:162
 		te = p
 		p--
 		{
@@ -1366,7 +1384,7 @@ func (l *lexer) next() token {
 //line NONE:1
 		ts = p
 
-//line lexer.go:916
+//line lexer.go:927
 		switch data[p] {
 		case 9:
 			goto tr110
@@ -1402,14 +1420,16 @@ func (l *lexer) next() token {
 			goto tr124
 		case 58:
 			goto tr126
+		case 59:
+			goto tr127
 		case 60:
 			goto st139
 		case 61:
-			goto tr128
+			goto tr129
 		case 62:
 			goto st140
 		case 63:
-			goto tr130
+			goto tr131
 		case 65:
 			goto st141
 		case 66:
@@ -1433,9 +1453,9 @@ func (l *lexer) next() token {
 		case 87:
 			goto st224
 		case 91:
-			goto tr144
-		case 93:
 			goto tr145
+		case 93:
+			goto tr146
 		case 97:
 			goto st141
 		case 98:
@@ -1457,9 +1477,9 @@ func (l *lexer) next() token {
 		case 119:
 			goto st224
 		case 123:
-			goto tr146
-		case 125:
 			goto tr147
+		case 125:
+			goto tr148
 		}
 		switch {
 		case data[p] < 71:
@@ -1475,13 +1495,13 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 101:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 99:
 				goto st161
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
 		goto tr109
 	st91:
@@ -1492,36 +1512,36 @@ func (l *lexer) next() token {
 		if data[p] == 10 {
 			goto tr111
 		}
-		goto tr148
+		goto tr149
 	st92:
 		if p++; p == pe {
 			goto _test_eof92
 		}
 	st_case_92:
 		if data[p] == 61 {
-			goto tr149
+			goto tr150
 		}
-		goto tr148
+		goto tr149
 	tr4:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:190
-		act = 50
+//line lexer.rl:197
+		act = 51
 		goto st93
 	tr114:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:193
-		act = 53
+//line lexer.rl:200
+		act = 54
 		goto st93
 	st93:
 		if p++; p == pe {
 			goto _test_eof93
 		}
 	st_case_93:
-//line lexer.go:1071
+//line lexer.go:1084
 		switch data[p] {
 		case 10:
 			goto tr0
@@ -1569,15 +1589,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:193
-		act = 53
+//line lexer.rl:200
+		act = 54
 		goto st94
 	st94:
 		if p++; p == pe {
 			goto _test_eof94
 		}
 	st_case_94:
-//line lexer.go:1127
+//line lexer.go:1140
 		if data[p] == 36 {
 			goto tr6
 		}
@@ -1595,32 +1615,32 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:184
-		act = 44
+//line lexer.rl:191
+		act = 45
 		goto st95
 	st95:
 		if p++; p == pe {
 			goto _test_eof95
 		}
 	st_case_95:
-//line lexer.go:1153
+//line lexer.go:1166
 		if data[p] == 36 {
 			goto st2
 		}
-		goto tr150
+		goto tr151
 	tr116:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:193
-		act = 53
+//line lexer.rl:200
+		act = 54
 		goto st96
 	st96:
 		if p++; p == pe {
 			goto _test_eof96
 		}
 	st_case_96:
-//line lexer.go:1170
+//line lexer.go:1183
 		if data[p] == 39 {
 			goto tr8
 		}
@@ -1638,28 +1658,28 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:184
-		act = 44
+//line lexer.rl:191
+		act = 45
 		goto st97
 	st97:
 		if p++; p == pe {
 			goto _test_eof97
 		}
 	st_case_97:
-//line lexer.go:1196
+//line lexer.go:1209
 		if data[p] == 39 {
 			goto st3
 		}
-		goto tr150
+		goto tr151
 	st98:
 		if p++; p == pe {
 			goto _test_eof98
 		}
 	st_case_98:
 		if data[p] == 61 {
-			goto tr152
+			goto tr153
 		}
-		goto tr151
+		goto tr152
 	tr122:
 //line NONE:1
 		te = p + 1
@@ -1670,41 +1690,41 @@ func (l *lexer) next() token {
 			goto _test_eof99
 		}
 	st_case_99:
-//line lexer.go:1220
+//line lexer.go:1233
 		switch data[p] {
 		case 61:
-			goto tr155
+			goto tr156
 		case 73:
 			goto st9
 		case 78:
 			goto st16
 		case 80:
-			goto tr158
+			goto tr159
 		case 105:
 			goto st9
 		case 110:
 			goto st16
 		}
 		if 48 <= data[p] && data[p] <= 57 {
-			goto tr154
+			goto tr155
 		}
-		goto tr153
-	tr154:
+		goto tr154
+	tr155:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st100
 	st100:
 		if p++; p == pe {
 			goto _test_eof100
 		}
 	st_case_100:
-//line lexer.go:1251
+//line lexer.go:1264
 		switch data[p] {
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
 			goto tr13
 		case 69:
@@ -1745,22 +1765,22 @@ func (l *lexer) next() token {
 			goto st8
 		}
 		if 48 <= data[p] && data[p] <= 57 {
-			goto tr154
+			goto tr155
 		}
-		goto tr159
-	tr160:
+		goto tr160
+	tr161:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st101
 	st101:
 		if p++; p == pe {
 			goto _test_eof101
 		}
 	st_case_101:
-//line lexer.go:1310
+//line lexer.go:1323
 		switch data[p] {
 		case 69:
 			goto st4
@@ -1768,9 +1788,9 @@ func (l *lexer) next() token {
 			goto st4
 		}
 		if 48 <= data[p] && data[p] <= 57 {
-			goto tr160
+			goto tr161
 		}
-		goto tr162
+		goto tr163
 	st4:
 		if p++; p == pe {
 			goto _test_eof4
@@ -1803,24 +1823,24 @@ func (l *lexer) next() token {
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st102
 		}
-		goto tr162
+		goto tr163
 	tr13:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st103
 	st103:
 		if p++; p == pe {
 			goto _test_eof103
 		}
 	st_case_103:
-//line lexer.go:1366
+//line lexer.go:1379
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st6
 		}
-		goto tr163
+		goto tr164
 	st6:
 		if p++; p == pe {
 			goto _test_eof6
@@ -1870,15 +1890,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st104
 	st104:
 		if p++; p == pe {
 			goto _test_eof104
 		}
 	st_case_104:
-//line lexer.go:1428
+//line lexer.go:1441
 		switch data[p] {
 		case 79:
 			goto tr13
@@ -1892,7 +1912,7 @@ func (l *lexer) next() token {
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st6
 		}
-		goto tr163
+		goto tr164
 	st7:
 		if p++; p == pe {
 			goto _test_eof7
@@ -2022,26 +2042,26 @@ func (l *lexer) next() token {
 			goto tr26
 		}
 		goto tr17
-	tr158:
+	tr159:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st105
 	st105:
 		if p++; p == pe {
 			goto _test_eof105
 		}
 	st_case_105:
-//line lexer.go:1584
+//line lexer.go:1597
 		if data[p] == 84 {
-			goto tr165
+			goto tr166
 		}
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st18
 		}
-		goto tr163
+		goto tr164
 	st18:
 		if p++; p == pe {
 			goto _test_eof18
@@ -2271,10 +2291,10 @@ func (l *lexer) next() token {
 		}
 	st_case_106:
 		if data[p] == 84 {
-			goto tr165
+			goto tr166
 		}
-		goto tr163
-	tr165:
+		goto tr164
+	tr166:
 //line NONE:1
 		te = p + 1
 
@@ -2284,11 +2304,11 @@ func (l *lexer) next() token {
 			goto _test_eof107
 		}
 	st_case_107:
-//line lexer.go:1834
+//line lexer.go:1847
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st37
 		}
-		goto tr163
+		goto tr164
 	st37:
 		if p++; p == pe {
 			goto _test_eof37
@@ -2316,11 +2336,11 @@ func (l *lexer) next() token {
 			goto _test_eof108
 		}
 	st_case_108:
-//line lexer.go:1866
+//line lexer.go:1879
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st38
 		}
-		goto tr163
+		goto tr164
 	st38:
 		if p++; p == pe {
 			goto _test_eof38
@@ -2346,11 +2366,11 @@ func (l *lexer) next() token {
 			goto _test_eof109
 		}
 	st_case_109:
-//line lexer.go:1896
+//line lexer.go:1909
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st39
 		}
-		goto tr163
+		goto tr164
 	st39:
 		if p++; p == pe {
 			goto _test_eof39
@@ -2373,14 +2393,14 @@ func (l *lexer) next() token {
 			goto _test_eof110
 		}
 	st_case_110:
-//line lexer.go:1923
+//line lexer.go:1936
 		if data[p] == 84 {
-			goto tr165
+			goto tr166
 		}
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st40
 		}
-		goto tr163
+		goto tr164
 	st40:
 		if p++; p == pe {
 			goto _test_eof40
@@ -2403,14 +2423,14 @@ func (l *lexer) next() token {
 			goto _test_eof111
 		}
 	st_case_111:
-//line lexer.go:1953
+//line lexer.go:1966
 		if data[p] == 84 {
-			goto tr165
+			goto tr166
 		}
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st41
 		}
-		goto tr163
+		goto tr164
 	st41:
 		if p++; p == pe {
 			goto _test_eof41
@@ -2430,20 +2450,20 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st112
 	st112:
 		if p++; p == pe {
 			goto _test_eof112
 		}
 	st_case_112:
-//line lexer.go:1988
+//line lexer.go:2001
 		switch data[p] {
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
-			goto tr168
+			goto tr169
 		case 69:
 			goto st89
 		case 72:
@@ -2459,7 +2479,7 @@ func (l *lexer) next() token {
 		case 88:
 			goto st137
 		case 100:
-			goto tr168
+			goto tr169
 		case 101:
 			goto st89
 		case 104:
@@ -2485,7 +2505,7 @@ func (l *lexer) next() token {
 					goto st87
 				}
 			case data[p] >= 48:
-				goto tr166
+				goto tr167
 			}
 		case data[p] > 89:
 			switch {
@@ -2499,25 +2519,25 @@ func (l *lexer) next() token {
 		default:
 			goto tr13
 		}
-		goto tr159
-	tr166:
+		goto tr160
+	tr167:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st113
 	st113:
 		if p++; p == pe {
 			goto _test_eof113
 		}
 	st_case_113:
-//line lexer.go:2062
+//line lexer.go:2075
 		switch data[p] {
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
-			goto tr172
+			goto tr173
 		case 69:
 			goto st86
 		case 72:
@@ -2535,7 +2555,7 @@ func (l *lexer) next() token {
 		case 89:
 			goto tr13
 		case 100:
-			goto tr172
+			goto tr173
 		case 101:
 			goto st86
 		case 104:
@@ -2558,7 +2578,7 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr171
+				goto tr172
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -2567,23 +2587,23 @@ func (l *lexer) next() token {
 		default:
 			goto st84
 		}
-		goto tr159
-	tr171:
+		goto tr160
+	tr172:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st114
 	st114:
 		if p++; p == pe {
 			goto _test_eof114
 		}
 	st_case_114:
-//line lexer.go:2130
+//line lexer.go:2143
 		switch data[p] {
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
 			goto tr107
 		case 69:
@@ -2626,7 +2646,7 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr174
+				goto tr175
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -2635,23 +2655,23 @@ func (l *lexer) next() token {
 		default:
 			goto st81
 		}
-		goto tr159
-	tr174:
+		goto tr160
+	tr175:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st115
 	st115:
 		if p++; p == pe {
 			goto _test_eof115
 		}
 	st_case_115:
-//line lexer.go:2198
+//line lexer.go:2211
 		switch data[p] {
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
 			goto tr103
 		case 69:
@@ -2694,7 +2714,7 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr176
+				goto tr177
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -2703,23 +2723,23 @@ func (l *lexer) next() token {
 		default:
 			goto st78
 		}
-		goto tr159
-	tr176:
+		goto tr160
+	tr177:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st116
 	st116:
 		if p++; p == pe {
 			goto _test_eof116
 		}
 	st_case_116:
-//line lexer.go:2266
+//line lexer.go:2279
 		switch data[p] {
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
 			goto tr99
 		case 69:
@@ -2762,7 +2782,7 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr178
+				goto tr179
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -2771,23 +2791,23 @@ func (l *lexer) next() token {
 		default:
 			goto st75
 		}
-		goto tr159
-	tr178:
+		goto tr160
+	tr179:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st117
 	st117:
 		if p++; p == pe {
 			goto _test_eof117
 		}
 	st_case_117:
-//line lexer.go:2334
+//line lexer.go:2347
 		switch data[p] {
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
 			goto tr95
 		case 69:
@@ -2830,7 +2850,7 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr180
+				goto tr181
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -2839,23 +2859,23 @@ func (l *lexer) next() token {
 		default:
 			goto st72
 		}
-		goto tr159
-	tr180:
+		goto tr160
+	tr181:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st118
 	st118:
 		if p++; p == pe {
 			goto _test_eof118
 		}
 	st_case_118:
-//line lexer.go:2402
+//line lexer.go:2415
 		switch data[p] {
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
 			goto tr91
 		case 69:
@@ -2898,7 +2918,7 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr182
+				goto tr183
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -2907,25 +2927,25 @@ func (l *lexer) next() token {
 		default:
 			goto st69
 		}
-		goto tr159
-	tr182:
+		goto tr160
+	tr183:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st119
 	st119:
 		if p++; p == pe {
 			goto _test_eof119
 		}
 	st_case_119:
-//line lexer.go:2470
+//line lexer.go:2483
 		switch data[p] {
 		case 45:
 			goto st42
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
 			goto tr13
 		case 69:
@@ -2966,9 +2986,9 @@ func (l *lexer) next() token {
 			goto st8
 		}
 		if 48 <= data[p] && data[p] <= 57 {
-			goto tr154
+			goto tr155
 		}
-		goto tr159
+		goto tr160
 	st42:
 		if p++; p == pe {
 			goto _test_eof42
@@ -3441,22 +3461,22 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st120
 	st120:
 		if p++; p == pe {
 			goto _test_eof120
 		}
 	st_case_120:
-//line lexer.go:2999
+//line lexer.go:3012
 		if data[p] == 45 {
 			goto st42
 		}
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st6
 		}
-		goto tr163
+		goto tr164
 	st70:
 		if p++; p == pe {
 			goto _test_eof70
@@ -3494,19 +3514,19 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st121
 	st121:
 		if p++; p == pe {
 			goto _test_eof121
 		}
 	st_case_121:
-//line lexer.go:3052
+//line lexer.go:3065
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr184
+				goto tr185
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -3515,24 +3535,24 @@ func (l *lexer) next() token {
 		default:
 			goto st44
 		}
-		goto tr162
-	tr184:
+		goto tr163
+	tr185:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st122
 	st122:
 		if p++; p == pe {
 			goto _test_eof122
 		}
 	st_case_122:
-//line lexer.go:3078
+//line lexer.go:3091
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr185
+				goto tr186
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -3541,24 +3561,24 @@ func (l *lexer) next() token {
 		default:
 			goto st45
 		}
-		goto tr162
-	tr185:
+		goto tr163
+	tr186:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st123
 	st123:
 		if p++; p == pe {
 			goto _test_eof123
 		}
 	st_case_123:
-//line lexer.go:3104
+//line lexer.go:3117
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr186
+				goto tr187
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -3567,27 +3587,27 @@ func (l *lexer) next() token {
 		default:
 			goto st46
 		}
-		goto tr162
-	tr186:
+		goto tr163
+	tr187:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st124
 	st124:
 		if p++; p == pe {
 			goto _test_eof124
 		}
 	st_case_124:
-//line lexer.go:3130
+//line lexer.go:3143
 		if data[p] == 45 {
 			goto st47
 		}
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st102
 		}
-		goto tr162
+		goto tr163
 	st72:
 		if p++; p == pe {
 			goto _test_eof72
@@ -3610,15 +3630,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st125
 	st125:
 		if p++; p == pe {
 			goto _test_eof125
 		}
 	st_case_125:
-//line lexer.go:3168
+//line lexer.go:3181
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -3631,7 +3651,7 @@ func (l *lexer) next() token {
 		default:
 			goto st69
 		}
-		goto tr163
+		goto tr164
 	st73:
 		if p++; p == pe {
 			goto _test_eof73
@@ -3707,22 +3727,22 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st126
 	st126:
 		if p++; p == pe {
 			goto _test_eof126
 		}
 	st_case_126:
-//line lexer.go:3265
+//line lexer.go:3278
 		if data[p] == 45 {
 			goto st42
 		}
 		if 48 <= data[p] && data[p] <= 57 {
 			goto st102
 		}
-		goto tr162
+		goto tr163
 	st75:
 		if p++; p == pe {
 			goto _test_eof75
@@ -3745,15 +3765,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st127
 	st127:
 		if p++; p == pe {
 			goto _test_eof127
 		}
 	st_case_127:
-//line lexer.go:3303
+//line lexer.go:3316
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -3766,7 +3786,7 @@ func (l *lexer) next() token {
 		default:
 			goto st72
 		}
-		goto tr163
+		goto tr164
 	st76:
 		if p++; p == pe {
 			goto _test_eof76
@@ -3849,15 +3869,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st128
 	st128:
 		if p++; p == pe {
 			goto _test_eof128
 		}
 	st_case_128:
-//line lexer.go:3407
+//line lexer.go:3420
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -3870,7 +3890,7 @@ func (l *lexer) next() token {
 		default:
 			goto st69
 		}
-		goto tr162
+		goto tr163
 	st78:
 		if p++; p == pe {
 			goto _test_eof78
@@ -3893,15 +3913,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st129
 	st129:
 		if p++; p == pe {
 			goto _test_eof129
 		}
 	st_case_129:
-//line lexer.go:3451
+//line lexer.go:3464
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -3914,7 +3934,7 @@ func (l *lexer) next() token {
 		default:
 			goto st75
 		}
-		goto tr163
+		goto tr164
 	st79:
 		if p++; p == pe {
 			goto _test_eof79
@@ -3997,15 +4017,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st130
 	st130:
 		if p++; p == pe {
 			goto _test_eof130
 		}
 	st_case_130:
-//line lexer.go:3555
+//line lexer.go:3568
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -4018,7 +4038,7 @@ func (l *lexer) next() token {
 		default:
 			goto st72
 		}
-		goto tr162
+		goto tr163
 	st81:
 		if p++; p == pe {
 			goto _test_eof81
@@ -4041,15 +4061,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st131
 	st131:
 		if p++; p == pe {
 			goto _test_eof131
 		}
 	st_case_131:
-//line lexer.go:3599
+//line lexer.go:3612
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -4062,7 +4082,7 @@ func (l *lexer) next() token {
 		default:
 			goto st78
 		}
-		goto tr163
+		goto tr164
 	st82:
 		if p++; p == pe {
 			goto _test_eof82
@@ -4145,15 +4165,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st132
 	st132:
 		if p++; p == pe {
 			goto _test_eof132
 		}
 	st_case_132:
-//line lexer.go:3703
+//line lexer.go:3716
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -4166,7 +4186,7 @@ func (l *lexer) next() token {
 		default:
 			goto st75
 		}
-		goto tr162
+		goto tr163
 	st84:
 		if p++; p == pe {
 			goto _test_eof84
@@ -4185,19 +4205,19 @@ func (l *lexer) next() token {
 			goto st81
 		}
 		goto tr0
-	tr172:
+	tr173:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st133
 	st133:
 		if p++; p == pe {
 			goto _test_eof133
 		}
 	st_case_133:
-//line lexer.go:3747
+//line lexer.go:3760
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -4210,7 +4230,7 @@ func (l *lexer) next() token {
 		default:
 			goto st81
 		}
-		goto tr163
+		goto tr164
 	st85:
 		if p++; p == pe {
 			goto _test_eof85
@@ -4293,15 +4313,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st134
 	st134:
 		if p++; p == pe {
 			goto _test_eof134
 		}
 	st_case_134:
-//line lexer.go:3851
+//line lexer.go:3864
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -4314,7 +4334,7 @@ func (l *lexer) next() token {
 		default:
 			goto st78
 		}
-		goto tr162
+		goto tr163
 	st87:
 		if p++; p == pe {
 			goto _test_eof87
@@ -4333,19 +4353,19 @@ func (l *lexer) next() token {
 			goto st84
 		}
 		goto tr84
-	tr168:
+	tr169:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st135
 	st135:
 		if p++; p == pe {
 			goto _test_eof135
 		}
 	st_case_135:
-//line lexer.go:3895
+//line lexer.go:3908
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -4358,7 +4378,7 @@ func (l *lexer) next() token {
 		default:
 			goto st84
 		}
-		goto tr163
+		goto tr164
 	st88:
 		if p++; p == pe {
 			goto _test_eof88
@@ -4441,15 +4461,15 @@ func (l *lexer) next() token {
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:186
-		act = 46
+//line lexer.rl:193
+		act = 47
 		goto st136
 	st136:
 		if p++; p == pe {
 			goto _test_eof136
 		}
 	st_case_136:
-//line lexer.go:3999
+//line lexer.go:4012
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
@@ -4462,7 +4482,7 @@ func (l *lexer) next() token {
 		default:
 			goto st81
 		}
-		goto tr162
+		goto tr163
 	st137:
 		if p++; p == pe {
 			goto _test_eof137
@@ -4480,25 +4500,25 @@ func (l *lexer) next() token {
 		default:
 			goto st137
 		}
-		goto tr188
+		goto tr189
 	tr125:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:185
-		act = 45
+//line lexer.rl:192
+		act = 46
 		goto st138
 	st138:
 		if p++; p == pe {
 			goto _test_eof138
 		}
 	st_case_138:
-//line lexer.go:4043
+//line lexer.go:4056
 		switch data[p] {
 		case 46:
-			goto tr160
+			goto tr161
 		case 68:
-			goto tr168
+			goto tr169
 		case 69:
 			goto st89
 		case 72:
@@ -4516,7 +4536,7 @@ func (l *lexer) next() token {
 		case 89:
 			goto tr13
 		case 100:
-			goto tr168
+			goto tr169
 		case 101:
 			goto st89
 		case 104:
@@ -4539,7 +4559,7 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr166
+				goto tr167
 			}
 		case data[p] > 70:
 			if 97 <= data[p] && data[p] <= 102 {
@@ -4548,25 +4568,25 @@ func (l *lexer) next() token {
 		default:
 			goto st87
 		}
-		goto tr159
+		goto tr160
 	st139:
 		if p++; p == pe {
 			goto _test_eof139
 		}
 	st_case_139:
 		if data[p] == 61 {
-			goto tr190
+			goto tr191
 		}
-		goto tr189
+		goto tr190
 	st140:
 		if p++; p == pe {
 			goto _test_eof140
 		}
 	st_case_140:
 		if data[p] == 61 {
-			goto tr192
+			goto tr193
 		}
-		goto tr191
+		goto tr192
 	st141:
 		if p++; p == pe {
 			goto _test_eof141
@@ -4578,7 +4598,7 @@ func (l *lexer) next() token {
 		case 80:
 			goto st151
 		case 95:
-			goto tr136
+			goto tr137
 		case 110:
 			goto st150
 		case 112:
@@ -4598,22 +4618,22 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st142
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st142:
 		if p++; p == pe {
 			goto _test_eof142
 		}
 	st_case_142:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 71:
@@ -4629,22 +4649,22 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st143
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st143:
 		if p++; p == pe {
 			goto _test_eof143
 		}
 	st_case_143:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 71:
@@ -4660,22 +4680,22 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st144
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st144:
 		if p++; p == pe {
 			goto _test_eof144
 		}
 	st_case_144:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 71:
@@ -4691,22 +4711,22 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st145
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st145:
 		if p++; p == pe {
 			goto _test_eof145
 		}
 	st_case_145:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 71:
@@ -4722,22 +4742,22 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st146
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st146:
 		if p++; p == pe {
 			goto _test_eof146
 		}
 	st_case_146:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 71:
@@ -4753,237 +4773,237 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st147
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st147:
 		if p++; p == pe {
 			goto _test_eof147
 		}
 	st_case_147:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 71:
 			switch {
 			case data[p] > 57:
 				if 65 <= data[p] && data[p] <= 70 {
-					goto tr202
+					goto tr203
 				}
 			case data[p] >= 48:
-				goto tr202
+				goto tr203
 			}
 		case data[p] > 90:
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
-				goto tr202
+				goto tr203
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
-	tr202:
+		goto tr194
+	tr203:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:190
-		act = 50
+//line lexer.rl:197
+		act = 51
 		goto st148
 	st148:
 		if p++; p == pe {
 			goto _test_eof148
 		}
 	st_case_148:
-//line lexer.go:4355
+//line lexer.go:4368
 		switch data[p] {
 		case 45:
 			goto st42
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
-	tr136:
+		goto tr194
+	tr137:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:190
-		act = 50
+//line lexer.rl:197
+		act = 51
 		goto st149
-	tr255:
+	tr256:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:188
-		act = 48
+//line lexer.rl:195
+		act = 49
 		goto st149
-	tr203:
+	tr204:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:154
+//line lexer.rl:160
 		act = 14
 		goto st149
-	tr206:
+	tr207:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:147
+//line lexer.rl:153
 		act = 7
 		goto st149
-	tr211:
+	tr212:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:145
+//line lexer.rl:151
 		act = 5
 		goto st149
-	tr214:
+	tr215:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:146
+//line lexer.rl:152
 		act = 6
 		goto st149
-	tr219:
+	tr220:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:144
+//line lexer.rl:150
 		act = 4
 		goto st149
-	tr224:
+	tr225:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:159
+//line lexer.rl:165
 		act = 19
-		goto st149
-	tr226:
-//line NONE:1
-		te = p + 1
-
-//line lexer.rl:149
-		act = 9
 		goto st149
 	tr227:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:152
+//line lexer.rl:155
+		act = 9
+		goto st149
+	tr228:
+//line NONE:1
+		te = p + 1
+
+//line lexer.rl:158
 		act = 12
 		goto st149
-	tr229:
+	tr230:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:155
+//line lexer.rl:161
 		act = 15
 		goto st149
-	tr238:
+	tr239:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:183
+//line lexer.rl:189
 		act = 43
-		goto st149
-	tr241:
-//line NONE:1
-		te = p + 1
-
-//line lexer.rl:142
-		act = 2
 		goto st149
 	tr242:
 //line NONE:1
 		te = p + 1
 
 //line lexer.rl:148
-		act = 8
+		act = 2
 		goto st149
-	tr246:
+	tr243:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:182
-		act = 42
+//line lexer.rl:154
+		act = 8
 		goto st149
 	tr247:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:157
+//line lexer.rl:188
+		act = 42
+		goto st149
+	tr248:
+//line NONE:1
+		te = p + 1
+
+//line lexer.rl:163
 		act = 17
 		goto st149
-	tr249:
+	tr250:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:160
+//line lexer.rl:166
 		act = 20
 		goto st149
-	tr271:
+	tr272:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:141
+//line lexer.rl:147
 		act = 1
 		goto st149
-	tr276:
+	tr277:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:158
+//line lexer.rl:164
 		act = 18
-		goto st149
-	tr282:
-//line NONE:1
-		te = p + 1
-
-//line lexer.rl:143
-		act = 3
 		goto st149
 	tr283:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:150
+//line lexer.rl:149
+		act = 3
+		goto st149
+	tr284:
+//line NONE:1
+		te = p + 1
+
+//line lexer.rl:156
 		act = 10
 		goto st149
-	tr286:
+	tr287:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:151
+//line lexer.rl:157
 		act = 11
 		goto st149
-	tr290:
+	tr291:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:153
+//line lexer.rl:159
 		act = 13
 		goto st149
 	st149:
@@ -4991,21 +5011,21 @@ func (l *lexer) next() token {
 			goto _test_eof149
 		}
 	st_case_149:
-//line lexer.go:4541
+//line lexer.go:4554
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
 		goto tr0
 	st150:
@@ -5015,25 +5035,25 @@ func (l *lexer) next() token {
 	st_case_150:
 		switch data[p] {
 		case 68:
-			goto tr203
+			goto tr204
 		case 95:
-			goto tr136
+			goto tr137
 		case 100:
-			goto tr203
+			goto tr204
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st151:
 		if p++; p == pe {
 			goto _test_eof151
@@ -5043,23 +5063,23 @@ func (l *lexer) next() token {
 		case 80:
 			goto st152
 		case 95:
-			goto tr136
+			goto tr137
 		case 112:
 			goto st152
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st152:
 		if p++; p == pe {
 			goto _test_eof152
@@ -5069,23 +5089,23 @@ func (l *lexer) next() token {
 		case 76:
 			goto st153
 		case 95:
-			goto tr136
+			goto tr137
 		case 108:
 			goto st153
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st153:
 		if p++; p == pe {
 			goto _test_eof153
@@ -5093,25 +5113,25 @@ func (l *lexer) next() token {
 	st_case_153:
 		switch data[p] {
 		case 89:
-			goto tr206
+			goto tr207
 		case 95:
-			goto tr136
+			goto tr137
 		case 121:
-			goto tr206
+			goto tr207
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st154:
 		if p++; p == pe {
 			goto _test_eof154
@@ -5123,7 +5143,7 @@ func (l *lexer) next() token {
 		case 69:
 			goto st158
 		case 95:
-			goto tr136
+			goto tr137
 		case 97:
 			goto st155
 		case 101:
@@ -5143,15 +5163,15 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 98:
 				goto st142
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st155:
 		if p++; p == pe {
 			goto _test_eof155
@@ -5161,7 +5181,7 @@ func (l *lexer) next() token {
 		case 84:
 			goto st156
 		case 95:
-			goto tr136
+			goto tr137
 		case 116:
 			goto st156
 		}
@@ -5179,15 +5199,15 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st143
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st156:
 		if p++; p == pe {
 			goto _test_eof156
@@ -5197,23 +5217,23 @@ func (l *lexer) next() token {
 		case 67:
 			goto st157
 		case 95:
-			goto tr136
+			goto tr137
 		case 99:
 			goto st157
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st157:
 		if p++; p == pe {
 			goto _test_eof157
@@ -5221,25 +5241,25 @@ func (l *lexer) next() token {
 	st_case_157:
 		switch data[p] {
 		case 72:
-			goto tr211
+			goto tr212
 		case 95:
-			goto tr136
+			goto tr137
 		case 104:
-			goto tr211
+			goto tr212
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st158:
 		if p++; p == pe {
 			goto _test_eof158
@@ -5249,7 +5269,7 @@ func (l *lexer) next() token {
 		case 71:
 			goto st159
 		case 95:
-			goto tr136
+			goto tr137
 		case 103:
 			goto st159
 		}
@@ -5267,15 +5287,15 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 104 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st143
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st159:
 		if p++; p == pe {
 			goto _test_eof159
@@ -5285,23 +5305,23 @@ func (l *lexer) next() token {
 		case 73:
 			goto st160
 		case 95:
-			goto tr136
+			goto tr137
 		case 105:
 			goto st160
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st160:
 		if p++; p == pe {
 			goto _test_eof160
@@ -5309,32 +5329,32 @@ func (l *lexer) next() token {
 	st_case_160:
 		switch data[p] {
 		case 78:
-			goto tr214
+			goto tr215
 		case 95:
-			goto tr136
+			goto tr137
 		case 110:
-			goto tr214
+			goto tr215
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st161:
 		if p++; p == pe {
 			goto _test_eof161
 		}
 	st_case_161:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 71:
@@ -5350,15 +5370,15 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st142
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st162:
 		if p++; p == pe {
 			goto _test_eof162
@@ -5368,7 +5388,7 @@ func (l *lexer) next() token {
 		case 69:
 			goto st163
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
 			goto st163
 		}
@@ -5386,15 +5406,15 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st142
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st163:
 		if p++; p == pe {
 			goto _test_eof163
@@ -5404,7 +5424,7 @@ func (l *lexer) next() token {
 		case 76:
 			goto st164
 		case 95:
-			goto tr136
+			goto tr137
 		case 108:
 			goto st164
 		}
@@ -5422,15 +5442,15 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st143
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st164:
 		if p++; p == pe {
 			goto _test_eof164
@@ -5440,23 +5460,23 @@ func (l *lexer) next() token {
 		case 69:
 			goto st165
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
 			goto st165
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st165:
 		if p++; p == pe {
 			goto _test_eof165
@@ -5466,23 +5486,23 @@ func (l *lexer) next() token {
 		case 84:
 			goto st166
 		case 95:
-			goto tr136
+			goto tr137
 		case 116:
 			goto st166
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st166:
 		if p++; p == pe {
 			goto _test_eof166
@@ -5490,25 +5510,25 @@ func (l *lexer) next() token {
 	st_case_166:
 		switch data[p] {
 		case 69:
-			goto tr219
+			goto tr220
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
-			goto tr219
+			goto tr220
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st167:
 		if p++; p == pe {
 			goto _test_eof167
@@ -5520,7 +5540,7 @@ func (l *lexer) next() token {
 		case 82:
 			goto st171
 		case 95:
-			goto tr136
+			goto tr137
 		case 97:
 			goto st168
 		case 114:
@@ -5540,15 +5560,15 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 98:
 				goto st142
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st168:
 		if p++; p == pe {
 			goto _test_eof168
@@ -5558,7 +5578,7 @@ func (l *lexer) next() token {
 		case 76:
 			goto st169
 		case 95:
-			goto tr136
+			goto tr137
 		case 108:
 			goto st169
 		}
@@ -5576,15 +5596,15 @@ func (l *lexer) next() token {
 			switch {
 			case data[p] > 102:
 				if 103 <= data[p] && data[p] <= 122 {
-					goto tr136
+					goto tr137
 				}
 			case data[p] >= 97:
 				goto st143
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st169:
 		if p++; p == pe {
 			goto _test_eof169
@@ -5594,23 +5614,23 @@ func (l *lexer) next() token {
 		case 83:
 			goto st170
 		case 95:
-			goto tr136
+			goto tr137
 		case 115:
 			goto st170
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st170:
 		if p++; p == pe {
 			goto _test_eof170
@@ -5618,25 +5638,25 @@ func (l *lexer) next() token {
 	st_case_170:
 		switch data[p] {
 		case 69:
-			goto tr224
+			goto tr225
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
-			goto tr224
+			goto tr225
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st171:
 		if p++; p == pe {
 			goto _test_eof171
@@ -5646,23 +5666,23 @@ func (l *lexer) next() token {
 		case 79:
 			goto st172
 		case 95:
-			goto tr136
+			goto tr137
 		case 111:
 			goto st172
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st172:
 		if p++; p == pe {
 			goto _test_eof172
@@ -5670,25 +5690,25 @@ func (l *lexer) next() token {
 	st_case_172:
 		switch data[p] {
 		case 77:
-			goto tr226
+			goto tr227
 		case 95:
-			goto tr136
+			goto tr137
 		case 109:
-			goto tr226
+			goto tr227
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st173:
 		if p++; p == pe {
 			goto _test_eof173
@@ -5696,33 +5716,33 @@ func (l *lexer) next() token {
 	st_case_173:
 		switch data[p] {
 		case 70:
-			goto tr227
+			goto tr228
 		case 78:
 			goto st174
 		case 83:
-			goto tr229
+			goto tr230
 		case 95:
-			goto tr136
+			goto tr137
 		case 102:
-			goto tr227
+			goto tr228
 		case 110:
 			goto st174
 		case 115:
-			goto tr229
+			goto tr230
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st174:
 		if p++; p == pe {
 			goto _test_eof174
@@ -5736,7 +5756,7 @@ func (l *lexer) next() token {
 		case 84:
 			goto st183
 		case 95:
-			goto tr136
+			goto tr137
 		case 102:
 			goto st175
 		case 115:
@@ -5747,16 +5767,16 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr230
+		goto tr231
 	st175:
 		if p++; p == pe {
 			goto _test_eof175
@@ -5766,23 +5786,23 @@ func (l *lexer) next() token {
 		case 73:
 			goto st176
 		case 95:
-			goto tr136
+			goto tr137
 		case 105:
 			goto st176
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st176:
 		if p++; p == pe {
 			goto _test_eof176
@@ -5792,23 +5812,23 @@ func (l *lexer) next() token {
 		case 78:
 			goto st177
 		case 95:
-			goto tr136
+			goto tr137
 		case 110:
 			goto st177
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st177:
 		if p++; p == pe {
 			goto _test_eof177
@@ -5818,23 +5838,23 @@ func (l *lexer) next() token {
 		case 73:
 			goto st178
 		case 95:
-			goto tr136
+			goto tr137
 		case 105:
 			goto st178
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st178:
 		if p++; p == pe {
 			goto _test_eof178
@@ -5844,23 +5864,23 @@ func (l *lexer) next() token {
 		case 84:
 			goto st179
 		case 95:
-			goto tr136
+			goto tr137
 		case 116:
 			goto st179
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st179:
 		if p++; p == pe {
 			goto _test_eof179
@@ -5868,25 +5888,25 @@ func (l *lexer) next() token {
 	st_case_179:
 		switch data[p] {
 		case 89:
-			goto tr238
+			goto tr239
 		case 95:
-			goto tr136
+			goto tr137
 		case 121:
-			goto tr238
+			goto tr239
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st180:
 		if p++; p == pe {
 			goto _test_eof180
@@ -5896,23 +5916,23 @@ func (l *lexer) next() token {
 		case 69:
 			goto st181
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
 			goto st181
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st181:
 		if p++; p == pe {
 			goto _test_eof181
@@ -5922,23 +5942,23 @@ func (l *lexer) next() token {
 		case 82:
 			goto st182
 		case 95:
-			goto tr136
+			goto tr137
 		case 114:
 			goto st182
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st182:
 		if p++; p == pe {
 			goto _test_eof182
@@ -5946,25 +5966,25 @@ func (l *lexer) next() token {
 	st_case_182:
 		switch data[p] {
 		case 84:
-			goto tr241
+			goto tr242
 		case 95:
-			goto tr136
+			goto tr137
 		case 116:
-			goto tr241
+			goto tr242
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st183:
 		if p++; p == pe {
 			goto _test_eof183
@@ -5972,25 +5992,25 @@ func (l *lexer) next() token {
 	st_case_183:
 		switch data[p] {
 		case 79:
-			goto tr242
+			goto tr243
 		case 95:
-			goto tr136
+			goto tr137
 		case 111:
-			goto tr242
+			goto tr243
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st184:
 		if p++; p == pe {
 			goto _test_eof184
@@ -6004,7 +6024,7 @@ func (l *lexer) next() token {
 		case 85:
 			goto st187
 		case 95:
-			goto tr136
+			goto tr137
 		case 97:
 			goto st185
 		case 111:
@@ -6015,16 +6035,16 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 66:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 98 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st185:
 		if p++; p == pe {
 			goto _test_eof185
@@ -6032,25 +6052,25 @@ func (l *lexer) next() token {
 	st_case_185:
 		switch data[p] {
 		case 78:
-			goto tr246
+			goto tr247
 		case 95:
-			goto tr136
+			goto tr137
 		case 110:
-			goto tr246
+			goto tr247
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st186:
 		if p++; p == pe {
 			goto _test_eof186
@@ -6058,25 +6078,25 @@ func (l *lexer) next() token {
 	st_case_186:
 		switch data[p] {
 		case 84:
-			goto tr247
+			goto tr248
 		case 95:
-			goto tr136
+			goto tr137
 		case 116:
-			goto tr247
+			goto tr248
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st187:
 		if p++; p == pe {
 			goto _test_eof187
@@ -6086,23 +6106,23 @@ func (l *lexer) next() token {
 		case 76:
 			goto st188
 		case 95:
-			goto tr136
+			goto tr137
 		case 108:
 			goto st188
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st188:
 		if p++; p == pe {
 			goto _test_eof188
@@ -6110,25 +6130,25 @@ func (l *lexer) next() token {
 	st_case_188:
 		switch data[p] {
 		case 76:
-			goto tr249
+			goto tr250
 		case 95:
-			goto tr136
+			goto tr137
 		case 108:
-			goto tr249
+			goto tr250
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st189:
 		if p++; p == pe {
 			goto _test_eof189
@@ -6138,7 +6158,7 @@ func (l *lexer) next() token {
 		case 84:
 			goto st196
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6147,12 +6167,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr163
+		goto tr164
 	st190:
 		if p++; p == pe {
 			goto _test_eof190
@@ -6164,11 +6184,11 @@ func (l *lexer) next() token {
 		case 77:
 			goto st202
 		case 87:
-			goto tr255
+			goto tr256
 		case 89:
 			goto st204
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6177,12 +6197,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st191:
 		if p++; p == pe {
 			goto _test_eof191
@@ -6194,11 +6214,11 @@ func (l *lexer) next() token {
 		case 77:
 			goto st202
 		case 87:
-			goto tr255
+			goto tr256
 		case 89:
 			goto st204
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6207,12 +6227,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st192:
 		if p++; p == pe {
 			goto _test_eof192
@@ -6224,38 +6244,38 @@ func (l *lexer) next() token {
 		case 77:
 			goto st202
 		case 87:
-			goto tr255
+			goto tr256
 		case 89:
 			goto st204
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr258
+				goto tr259
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
-	tr258:
+		goto tr194
+	tr259:
 //line NONE:1
 		te = p + 1
 
-//line lexer.rl:190
-		act = 50
+//line lexer.rl:197
+		act = 51
 		goto st193
 	st193:
 		if p++; p == pe {
 			goto _test_eof193
 		}
 	st_case_193:
-//line lexer.go:5805
+//line lexer.go:5818
 		switch data[p] {
 		case 45:
 			goto st22
@@ -6264,11 +6284,11 @@ func (l *lexer) next() token {
 		case 77:
 			goto st202
 		case 87:
-			goto tr255
+			goto tr256
 		case 89:
 			goto st204
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6277,12 +6297,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st194:
 		if p++; p == pe {
 			goto _test_eof194
@@ -6294,11 +6314,11 @@ func (l *lexer) next() token {
 		case 77:
 			goto st202
 		case 87:
-			goto tr255
+			goto tr256
 		case 89:
 			goto st204
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6307,12 +6327,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st195:
 		if p++; p == pe {
 			goto _test_eof195
@@ -6322,28 +6342,28 @@ func (l *lexer) next() token {
 		case 84:
 			goto st196
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr163
+		goto tr164
 	st196:
 		if p++; p == pe {
 			goto _test_eof196
 		}
 	st_case_196:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6352,12 +6372,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr163
+		goto tr164
 	st197:
 		if p++; p == pe {
 			goto _test_eof197
@@ -6369,9 +6389,9 @@ func (l *lexer) next() token {
 		case 77:
 			goto st200
 		case 83:
-			goto tr255
+			goto tr256
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6380,19 +6400,19 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st198:
 		if p++; p == pe {
 			goto _test_eof198
 		}
 	st_case_198:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6401,12 +6421,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr163
+		goto tr164
 	st199:
 		if p++; p == pe {
 			goto _test_eof199
@@ -6416,9 +6436,9 @@ func (l *lexer) next() token {
 		case 77:
 			goto st200
 		case 83:
-			goto tr255
+			goto tr256
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6427,19 +6447,19 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st200:
 		if p++; p == pe {
 			goto _test_eof200
 		}
 	st_case_200:
 		if data[p] == 95 {
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6448,12 +6468,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr163
+		goto tr164
 	st201:
 		if p++; p == pe {
 			goto _test_eof201
@@ -6461,9 +6481,9 @@ func (l *lexer) next() token {
 	st_case_201:
 		switch data[p] {
 		case 83:
-			goto tr255
+			goto tr256
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6472,12 +6492,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st202:
 		if p++; p == pe {
 			goto _test_eof202
@@ -6487,7 +6507,7 @@ func (l *lexer) next() token {
 		case 84:
 			goto st196
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6496,12 +6516,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr163
+		goto tr164
 	st203:
 		if p++; p == pe {
 			goto _test_eof203
@@ -6511,7 +6531,7 @@ func (l *lexer) next() token {
 		case 68:
 			goto st195
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6520,12 +6540,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st204:
 		if p++; p == pe {
 			goto _test_eof204
@@ -6535,7 +6555,7 @@ func (l *lexer) next() token {
 		case 84:
 			goto st196
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6544,12 +6564,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr163
+		goto tr164
 	st205:
 		if p++; p == pe {
 			goto _test_eof205
@@ -6561,7 +6581,7 @@ func (l *lexer) next() token {
 		case 77:
 			goto st202
 		case 95:
-			goto tr136
+			goto tr137
 		}
 		switch {
 		case data[p] < 65:
@@ -6570,12 +6590,12 @@ func (l *lexer) next() token {
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st206:
 		if p++; p == pe {
 			goto _test_eof206
@@ -6585,23 +6605,23 @@ func (l *lexer) next() token {
 		case 69:
 			goto st207
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
 			goto st207
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st207:
 		if p++; p == pe {
 			goto _test_eof207
@@ -6611,23 +6631,23 @@ func (l *lexer) next() token {
 		case 76:
 			goto st208
 		case 95:
-			goto tr136
+			goto tr137
 		case 108:
 			goto st208
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st208:
 		if p++; p == pe {
 			goto _test_eof208
@@ -6637,23 +6657,23 @@ func (l *lexer) next() token {
 		case 69:
 			goto st209
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
 			goto st209
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st209:
 		if p++; p == pe {
 			goto _test_eof209
@@ -6663,23 +6683,23 @@ func (l *lexer) next() token {
 		case 67:
 			goto st210
 		case 95:
-			goto tr136
+			goto tr137
 		case 99:
 			goto st210
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st210:
 		if p++; p == pe {
 			goto _test_eof210
@@ -6687,25 +6707,25 @@ func (l *lexer) next() token {
 	st_case_210:
 		switch data[p] {
 		case 84:
-			goto tr271
+			goto tr272
 		case 95:
-			goto tr136
+			goto tr137
 		case 116:
-			goto tr271
+			goto tr272
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st211:
 		if p++; p == pe {
 			goto _test_eof211
@@ -6717,7 +6737,7 @@ func (l *lexer) next() token {
 		case 82:
 			goto st215
 		case 95:
-			goto tr136
+			goto tr137
 		case 111:
 			goto st212
 		case 114:
@@ -6726,16 +6746,16 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st212:
 		if p++; p == pe {
 			goto _test_eof212
@@ -6745,23 +6765,23 @@ func (l *lexer) next() token {
 		case 75:
 			goto st213
 		case 95:
-			goto tr136
+			goto tr137
 		case 107:
 			goto st213
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st213:
 		if p++; p == pe {
 			goto _test_eof213
@@ -6771,23 +6791,23 @@ func (l *lexer) next() token {
 		case 69:
 			goto st214
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
 			goto st214
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st214:
 		if p++; p == pe {
 			goto _test_eof214
@@ -6795,25 +6815,25 @@ func (l *lexer) next() token {
 	st_case_214:
 		switch data[p] {
 		case 78:
-			goto tr276
+			goto tr277
 		case 95:
-			goto tr136
+			goto tr137
 		case 110:
-			goto tr276
+			goto tr277
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st215:
 		if p++; p == pe {
 			goto _test_eof215
@@ -6823,23 +6843,23 @@ func (l *lexer) next() token {
 		case 85:
 			goto st170
 		case 95:
-			goto tr136
+			goto tr137
 		case 117:
 			goto st170
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st216:
 		if p++; p == pe {
 			goto _test_eof216
@@ -6851,7 +6871,7 @@ func (l *lexer) next() token {
 		case 83:
 			goto st221
 		case 95:
-			goto tr136
+			goto tr137
 		case 112:
 			goto st217
 		case 115:
@@ -6860,16 +6880,16 @@ func (l *lexer) next() token {
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st217:
 		if p++; p == pe {
 			goto _test_eof217
@@ -6879,23 +6899,23 @@ func (l *lexer) next() token {
 		case 68:
 			goto st218
 		case 95:
-			goto tr136
+			goto tr137
 		case 100:
 			goto st218
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st218:
 		if p++; p == pe {
 			goto _test_eof218
@@ -6905,23 +6925,23 @@ func (l *lexer) next() token {
 		case 65:
 			goto st219
 		case 95:
-			goto tr136
+			goto tr137
 		case 97:
 			goto st219
 		}
 		switch {
 		case data[p] < 66:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 98 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st219:
 		if p++; p == pe {
 			goto _test_eof219
@@ -6931,23 +6951,23 @@ func (l *lexer) next() token {
 		case 84:
 			goto st220
 		case 95:
-			goto tr136
+			goto tr137
 		case 116:
 			goto st220
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st220:
 		if p++; p == pe {
 			goto _test_eof220
@@ -6955,25 +6975,25 @@ func (l *lexer) next() token {
 	st_case_220:
 		switch data[p] {
 		case 69:
-			goto tr282
+			goto tr283
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
-			goto tr282
+			goto tr283
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st221:
 		if p++; p == pe {
 			goto _test_eof221
@@ -6981,29 +7001,29 @@ func (l *lexer) next() token {
 	st_case_221:
 		switch data[p] {
 		case 69:
-			goto tr283
+			goto tr284
 		case 73:
 			goto st222
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
-			goto tr283
+			goto tr284
 		case 105:
 			goto st222
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st222:
 		if p++; p == pe {
 			goto _test_eof222
@@ -7013,23 +7033,23 @@ func (l *lexer) next() token {
 		case 78:
 			goto st223
 		case 95:
-			goto tr136
+			goto tr137
 		case 110:
 			goto st223
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st223:
 		if p++; p == pe {
 			goto _test_eof223
@@ -7037,25 +7057,25 @@ func (l *lexer) next() token {
 	st_case_223:
 		switch data[p] {
 		case 71:
-			goto tr286
+			goto tr287
 		case 95:
-			goto tr136
+			goto tr137
 		case 103:
-			goto tr286
+			goto tr287
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st224:
 		if p++; p == pe {
 			goto _test_eof224
@@ -7065,23 +7085,23 @@ func (l *lexer) next() token {
 		case 72:
 			goto st225
 		case 95:
-			goto tr136
+			goto tr137
 		case 104:
 			goto st225
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st225:
 		if p++; p == pe {
 			goto _test_eof225
@@ -7091,23 +7111,23 @@ func (l *lexer) next() token {
 		case 69:
 			goto st226
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
 			goto st226
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st226:
 		if p++; p == pe {
 			goto _test_eof226
@@ -7117,23 +7137,23 @@ func (l *lexer) next() token {
 		case 82:
 			goto st227
 		case 95:
-			goto tr136
+			goto tr137
 		case 114:
 			goto st227
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st227:
 		if p++; p == pe {
 			goto _test_eof227
@@ -7141,25 +7161,25 @@ func (l *lexer) next() token {
 	st_case_227:
 		switch data[p] {
 		case 69:
-			goto tr290
+			goto tr291
 		case 95:
-			goto tr136
+			goto tr137
 		case 101:
-			goto tr290
+			goto tr291
 		}
 		switch {
 		case data[p] < 65:
 			if 48 <= data[p] && data[p] <= 57 {
-				goto tr136
+				goto tr137
 			}
 		case data[p] > 90:
 			if 97 <= data[p] && data[p] <= 122 {
-				goto tr136
+				goto tr137
 			}
 		default:
-			goto tr136
+			goto tr137
 		}
-		goto tr193
+		goto tr194
 	st_out:
 	_test_eof90:
 		cs = 90
@@ -7852,9 +7872,9 @@ func (l *lexer) next() token {
 		if p == eof {
 			switch cs {
 			case 91:
-				goto tr148
+				goto tr149
 			case 92:
-				goto tr148
+				goto tr149
 			case 93:
 				goto tr0
 			case 0:
@@ -7862,37 +7882,37 @@ func (l *lexer) next() token {
 			case 1:
 				goto tr0
 			case 94:
-				goto tr148
+				goto tr149
 			case 2:
 				goto tr0
 			case 95:
-				goto tr150
+				goto tr151
 			case 96:
-				goto tr148
+				goto tr149
 			case 3:
 				goto tr0
 			case 97:
-				goto tr150
-			case 98:
 				goto tr151
+			case 98:
+				goto tr152
 			case 99:
-				goto tr153
+				goto tr154
 			case 100:
-				goto tr159
+				goto tr160
 			case 101:
-				goto tr162
+				goto tr163
 			case 4:
 				goto tr0
 			case 5:
 				goto tr0
 			case 102:
-				goto tr162
-			case 103:
 				goto tr163
+			case 103:
+				goto tr164
 			case 6:
 				goto tr11
 			case 104:
-				goto tr163
+				goto tr164
 			case 7:
 				goto tr0
 			case 8:
@@ -7916,7 +7936,7 @@ func (l *lexer) next() token {
 			case 17:
 				goto tr17
 			case 105:
-				goto tr163
+				goto tr164
 			case 18:
 				goto tr11
 			case 19:
@@ -7956,43 +7976,43 @@ func (l *lexer) next() token {
 			case 36:
 				goto tr11
 			case 106:
-				goto tr163
+				goto tr164
 			case 107:
-				goto tr163
+				goto tr164
 			case 37:
 				goto tr11
 			case 108:
-				goto tr163
+				goto tr164
 			case 38:
 				goto tr11
 			case 109:
-				goto tr163
+				goto tr164
 			case 39:
 				goto tr11
 			case 110:
-				goto tr163
+				goto tr164
 			case 40:
 				goto tr11
 			case 111:
-				goto tr163
+				goto tr164
 			case 41:
 				goto tr11
 			case 112:
-				goto tr159
+				goto tr160
 			case 113:
-				goto tr159
+				goto tr160
 			case 114:
-				goto tr159
+				goto tr160
 			case 115:
-				goto tr159
+				goto tr160
 			case 116:
-				goto tr159
+				goto tr160
 			case 117:
-				goto tr159
+				goto tr160
 			case 118:
-				goto tr159
+				goto tr160
 			case 119:
-				goto tr159
+				goto tr160
 			case 42:
 				goto tr0
 			case 43:
@@ -8050,261 +8070,261 @@ func (l *lexer) next() token {
 			case 69:
 				goto tr0
 			case 120:
-				goto tr163
+				goto tr164
 			case 70:
 				goto tr84
 			case 71:
 				goto tr84
 			case 121:
-				goto tr162
+				goto tr163
 			case 122:
-				goto tr162
+				goto tr163
 			case 123:
-				goto tr162
+				goto tr163
 			case 124:
-				goto tr162
+				goto tr163
 			case 72:
 				goto tr0
 			case 125:
-				goto tr163
+				goto tr164
 			case 73:
 				goto tr11
 			case 74:
 				goto tr84
 			case 126:
-				goto tr162
+				goto tr163
 			case 75:
 				goto tr0
 			case 127:
-				goto tr163
+				goto tr164
 			case 76:
 				goto tr11
 			case 77:
 				goto tr84
 			case 128:
-				goto tr162
+				goto tr163
 			case 78:
 				goto tr0
 			case 129:
-				goto tr163
+				goto tr164
 			case 79:
 				goto tr11
 			case 80:
 				goto tr84
 			case 130:
-				goto tr162
+				goto tr163
 			case 81:
 				goto tr0
 			case 131:
-				goto tr163
+				goto tr164
 			case 82:
 				goto tr11
 			case 83:
 				goto tr84
 			case 132:
-				goto tr162
+				goto tr163
 			case 84:
 				goto tr0
 			case 133:
-				goto tr163
+				goto tr164
 			case 85:
 				goto tr11
 			case 86:
 				goto tr84
 			case 134:
-				goto tr162
+				goto tr163
 			case 87:
 				goto tr84
 			case 135:
-				goto tr163
+				goto tr164
 			case 88:
 				goto tr11
 			case 89:
 				goto tr84
 			case 136:
-				goto tr162
+				goto tr163
 			case 137:
-				goto tr188
-			case 138:
-				goto tr159
-			case 139:
 				goto tr189
+			case 138:
+				goto tr160
+			case 139:
+				goto tr190
 			case 140:
-				goto tr191
+				goto tr192
 			case 141:
-				goto tr193
+				goto tr194
 			case 142:
-				goto tr193
+				goto tr194
 			case 143:
-				goto tr193
+				goto tr194
 			case 144:
-				goto tr193
+				goto tr194
 			case 145:
-				goto tr193
+				goto tr194
 			case 146:
-				goto tr193
+				goto tr194
 			case 147:
-				goto tr193
+				goto tr194
 			case 148:
-				goto tr193
+				goto tr194
 			case 149:
 				goto tr0
 			case 150:
-				goto tr193
+				goto tr194
 			case 151:
-				goto tr193
+				goto tr194
 			case 152:
-				goto tr193
+				goto tr194
 			case 153:
-				goto tr193
+				goto tr194
 			case 154:
-				goto tr193
+				goto tr194
 			case 155:
-				goto tr193
+				goto tr194
 			case 156:
-				goto tr193
+				goto tr194
 			case 157:
-				goto tr193
+				goto tr194
 			case 158:
-				goto tr193
+				goto tr194
 			case 159:
-				goto tr193
+				goto tr194
 			case 160:
-				goto tr193
+				goto tr194
 			case 161:
-				goto tr193
+				goto tr194
 			case 162:
-				goto tr193
+				goto tr194
 			case 163:
-				goto tr193
+				goto tr194
 			case 164:
-				goto tr193
+				goto tr194
 			case 165:
-				goto tr193
+				goto tr194
 			case 166:
-				goto tr193
+				goto tr194
 			case 167:
-				goto tr193
+				goto tr194
 			case 168:
-				goto tr193
+				goto tr194
 			case 169:
-				goto tr193
+				goto tr194
 			case 170:
-				goto tr193
+				goto tr194
 			case 171:
-				goto tr193
+				goto tr194
 			case 172:
-				goto tr193
+				goto tr194
 			case 173:
-				goto tr193
+				goto tr194
 			case 174:
-				goto tr230
+				goto tr231
 			case 175:
-				goto tr193
+				goto tr194
 			case 176:
-				goto tr193
+				goto tr194
 			case 177:
-				goto tr193
+				goto tr194
 			case 178:
-				goto tr193
+				goto tr194
 			case 179:
-				goto tr193
+				goto tr194
 			case 180:
-				goto tr193
+				goto tr194
 			case 181:
-				goto tr193
+				goto tr194
 			case 182:
-				goto tr193
+				goto tr194
 			case 183:
-				goto tr193
+				goto tr194
 			case 184:
-				goto tr193
+				goto tr194
 			case 185:
-				goto tr193
+				goto tr194
 			case 186:
-				goto tr193
+				goto tr194
 			case 187:
-				goto tr193
+				goto tr194
 			case 188:
-				goto tr193
+				goto tr194
 			case 189:
-				goto tr163
+				goto tr164
 			case 190:
-				goto tr193
+				goto tr194
 			case 191:
-				goto tr193
+				goto tr194
 			case 192:
-				goto tr193
+				goto tr194
 			case 193:
-				goto tr193
+				goto tr194
 			case 194:
-				goto tr193
+				goto tr194
 			case 195:
-				goto tr163
+				goto tr164
 			case 196:
-				goto tr163
+				goto tr164
 			case 197:
-				goto tr193
+				goto tr194
 			case 198:
-				goto tr163
+				goto tr164
 			case 199:
-				goto tr193
+				goto tr194
 			case 200:
-				goto tr163
+				goto tr164
 			case 201:
-				goto tr193
+				goto tr194
 			case 202:
-				goto tr163
+				goto tr164
 			case 203:
-				goto tr193
+				goto tr194
 			case 204:
-				goto tr163
+				goto tr164
 			case 205:
-				goto tr193
+				goto tr194
 			case 206:
-				goto tr193
+				goto tr194
 			case 207:
-				goto tr193
+				goto tr194
 			case 208:
-				goto tr193
+				goto tr194
 			case 209:
-				goto tr193
+				goto tr194
 			case 210:
-				goto tr193
+				goto tr194
 			case 211:
-				goto tr193
+				goto tr194
 			case 212:
-				goto tr193
+				goto tr194
 			case 213:
-				goto tr193
+				goto tr194
 			case 214:
-				goto tr193
+				goto tr194
 			case 215:
-				goto tr193
+				goto tr194
 			case 216:
-				goto tr193
+				goto tr194
 			case 217:
-				goto tr193
+				goto tr194
 			case 218:
-				goto tr193
+				goto tr194
 			case 219:
-				goto tr193
+				goto tr194
 			case 220:
-				goto tr193
+				goto tr194
 			case 221:
-				goto tr193
+				goto tr194
 			case 222:
-				goto tr193
+				goto tr194
 			case 223:
-				goto tr193
+				goto tr194
 			case 224:
-				goto tr193
+				goto tr194
 			case 225:
-				goto tr193
+				goto tr194
 			case 226:
-				goto tr193
+				goto tr194
 			case 227:
-				goto tr193
+				goto tr194
 			}
 		}
 
@@ -8313,7 +8333,7 @@ func (l *lexer) next() token {
 		}
 	}
 
-//line lexer.rl:198
+//line lexer.rl:205
 
 	l.p = p
 

--- a/parser/lexer.rl
+++ b/parser/lexer.rl
@@ -187,6 +187,7 @@ func (l *lexer) next() token {
             '-=' => { tk = tkSubEqual; fbreak; };
             '-'? /nan/i => { tk = tkNan; fbreak; };
             '-'? /infinity/i => { tk = tkInfinity; fbreak; };
+            ';' => { tk = tkEOF; fbreak; };
             pgstring | string => { tk = tkStringLiteral; fbreak; };
             integer => { tk = tkInteger; fbreak; };
             float => { tk = tkFloat; fbreak; };

--- a/parser/parse_delete.go
+++ b/parser/parse_delete.go
@@ -65,3 +65,12 @@ func isIdempotentDeleteStmt(l *lexer) (idempotent bool, err error) {
 
 	return true, nil
 }
+
+func isIdempotentDeleteElementTermType(typ termType) bool {
+	// Delete element terms can be one of the following:
+	// * Literal (idempotent, if not an integer literal)
+	// * Bind marker (ambiguous, so not idempotent)
+	// * Function call (ambiguous, so not idempotent)
+	// * Type cast (ambiguous)
+	return typ != termIntegerLiteral && typ != termBindMarker && typ != termFunctionCall && typ != termCast
+}

--- a/parser/parse_delete.go
+++ b/parser/parse_delete.go
@@ -66,11 +66,11 @@ func isIdempotentDeleteStmt(l *lexer) (idempotent bool, err error) {
 	return true, nil
 }
 
+// Delete element terms can be one of the following:
+// * Literal (idempotent, if not an integer literal)
+// * Bind marker (ambiguous, so not idempotent)
+// * Function call (ambiguous, so not idempotent)
+// * Type cast (ambiguous)
 func isIdempotentDeleteElementTermType(typ termType) bool {
-	// Delete element terms can be one of the following:
-	// * Literal (idempotent, if not an integer literal)
-	// * Bind marker (ambiguous, so not idempotent)
-	// * Function call (ambiguous, so not idempotent)
-	// * Type cast (ambiguous)
 	return typ != termIntegerLiteral && typ != termBindMarker && typ != termFunctionCall && typ != termCast
 }

--- a/parser/parse_delete_test.go
+++ b/parser/parse_delete_test.go
@@ -1,0 +1,1 @@
+package parser

--- a/parser/parse_delete_test.go
+++ b/parser/parse_delete_test.go
@@ -1,1 +1,60 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIdempotentDeleteStmt(t *testing.T) {
+	var tests = []struct {
+		query      string
+		idempotent bool
+		hasError   bool
+		msg        string
+	}{
+		{"DELETE FROM table", true, false, "simple table"},
+		{"DELETE a FROM table", true, false, "w/ operation"},
+		{"DELETE a FROM ks.table", true, false, "simple qualified table"},
+		{"DELETE a.b FROM table", true, false, "UDT field"},
+		{"DELETE a, b, c['key'] FROM table", true, false, "multiple operations"},
+		{"DELETE a['key'] FROM ks.table", true, false, "map field"},
+		{"DELETE a FROM table WHERE a > 0", true, false, "where clause"},
+
+		// Invalid
+		{"DELETE a. FROM table", false, true, "no UDT field"},
+		{"DELETE FROM ks.", true, false, "no table after '.'"},
+		{"DELETE FROM table WHERE", true, false, "where clause w/ no relation"},
+		{"DELETE a[0 table WHERE b > 0", false, true, "collection element with no closing square bracket"},
+
+		// Not idempotent
+		{"DELETE a, b, c[1] FROM ks.table", false, false, "multiple with list element"},
+		{"DELETE FROM ks.table WHERE a > toTimestamp(now())", false, false, "now() relation"},
+		{"DELETE FROM table WHERE a > 0 IF EXISTS", false, false, "LWT"},
+
+		// Ambiguous
+		{"DELETE a[0] FROM ks.table", false, false, "potentially a list element"},
+		{"DELETE a[?] FROM ks.table", false, false, "potentially a list element w/ bind marker"},
+		{"DELETE a[func()] FROM ks.table", false, false, "potentially a list element w/ function call"},
+	}
+
+	for _, tt := range tests {
+		idempotent, err := IsQueryIdempotent(tt.query)
+		assert.True(t, (err != nil) == tt.hasError, tt.msg)
+		assert.Equal(t, tt.idempotent, idempotent, "invalid idempotency", tt.msg)
+	}
+}

--- a/parser/parse_insert.go
+++ b/parser/parse_insert.go
@@ -70,7 +70,7 @@ func isIdempotentInsertStmt(l *lexer) (idempotent bool, err error) {
 		}
 	}
 
-	for t = l.next(); t != tkEOF; {
+	for t = l.next(); t != tkEOF; t = l.next() {
 		if tkIf == t {
 			return false, nil
 		}

--- a/parser/parse_insert.go
+++ b/parser/parse_insert.go
@@ -14,6 +14,68 @@
 
 package parser
 
+import "errors"
+
 func isIdempotentInsertStmt(l *lexer) (idempotent bool, err error) {
-	return false, nil
+	t := l.next()
+	if tkInto != t {
+		return false, errors.New("expected 'INTO' after 'INSERT' for insert statement")
+	}
+
+	if t = l.next(); tkIdentifier != t {
+		return false, errors.New("expected identifier after 'INTO' in insert statement")
+	}
+
+	_, _, t, err = parseQualifiedIdentifier(l)
+	if err != nil {
+		return false, err
+	}
+
+	if tkLparen != t {
+		return false, errors.New("expected '(' after table name for insert statement")
+	}
+
+	err = parseIdentifiers(l, l.next())
+	if err != nil {
+		return false, err
+	}
+
+	if !isUnreservedKeyword(l, l.next(), "values") {
+		return false, errors.New("expected 'VALUES' after identifiers in insert statement")
+	}
+
+	if t != l.next() {
+		return false, errors.New("expected '(' after 'VALUES' in insert statement")
+	}
+
+	for t = l.next(); tkRparen != t && tkEOF != t; t = skipToken(l, l.next(), tkComma) {
+		if idempotent, _, err = parseTerm(l, t); !idempotent {
+			return idempotent, err
+		}
+	}
+
+	if t != tkRparen {
+		return false, errors.New("expected closing ')' for 'VALUES' list in insert statement")
+	}
+
+	for t = l.next(); t != tkEOF; {
+		if tkIf == t {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func parseIdentifiers(l *lexer, t token) (err error) {
+	for tkRparen != t && tkEOF != t {
+		if tkIdentifier != t {
+			return errors.New("expected identifier")
+		}
+		t = skipToken(l, l.next(), tkComma)
+	}
+	if tkRparen != t {
+		return errors.New("expected closing ')' for identifiers")
+	}
+	return nil
 }

--- a/parser/parse_insert.go
+++ b/parser/parse_insert.go
@@ -16,6 +16,16 @@ package parser
 
 import "errors"
 
+// Determines if an insert statement is idempotent.
+//
+// An insert statement is not idempotent if it contains a non-idempotent term e.g. 'now()' or 'uuid()' or if it uses
+// lightweight transactions (LWTs) e.g. using 'IF NOT EXISTS'.
+//
+// insertStatement: 'INSERT' 'INTO' tableName ( namedValues | jsonClause ) ( 'IF' 'NOT' 'EXISTS' )?
+// tableName: ( identifier '.' )? identifier
+// namedValues: '(' identifiers ')' 'VALUES' '(' terms ')'
+// jsonClause: 'JSON' stringLiteral ( 'DEFAULT' ( 'NULL' | 'UNSET' ) )?
+//
 func isIdempotentInsertStmt(l *lexer) (idempotent bool, err error) {
 	t := l.next()
 	if tkInto != t {
@@ -31,31 +41,33 @@ func isIdempotentInsertStmt(l *lexer) (idempotent bool, err error) {
 		return false, err
 	}
 
-	if tkLparen != t {
-		return false, errors.New("expected '(' after table name for insert statement")
-	}
-
-	err = parseIdentifiers(l, l.next())
-	if err != nil {
-		return false, err
-	}
-
-	if !isUnreservedKeyword(l, l.next(), "values") {
-		return false, errors.New("expected 'VALUES' after identifiers in insert statement")
-	}
-
-	if t != l.next() {
-		return false, errors.New("expected '(' after 'VALUES' in insert statement")
-	}
-
-	for t = l.next(); tkRparen != t && tkEOF != t; t = skipToken(l, l.next(), tkComma) {
-		if idempotent, _, err = parseTerm(l, t); !idempotent {
-			return idempotent, err
+	if !isUnreservedKeyword(l, t, "json") {
+		if tkLparen != t {
+			return false, errors.New("expected '(' after table name for insert statement")
 		}
-	}
 
-	if t != tkRparen {
-		return false, errors.New("expected closing ')' for 'VALUES' list in insert statement")
+		err = parseIdentifiers(l, l.next())
+		if err != nil {
+			return false, err
+		}
+
+		if !isUnreservedKeyword(l, l.next(), "values") {
+			return false, errors.New("expected 'VALUES' after identifiers in insert statement")
+		}
+
+		if t != l.next() {
+			return false, errors.New("expected '(' after 'VALUES' in insert statement")
+		}
+
+		for t = l.next(); tkRparen != t && tkEOF != t; t = skipToken(l, l.next(), tkComma) {
+			if idempotent, _, err = parseTerm(l, t); !idempotent {
+				return idempotent, err
+			}
+		}
+
+		if t != tkRparen {
+			return false, errors.New("expected closing ')' for 'VALUES' list in insert statement")
+		}
 	}
 
 	for t = l.next(); t != tkEOF; {
@@ -65,17 +77,4 @@ func isIdempotentInsertStmt(l *lexer) (idempotent bool, err error) {
 	}
 
 	return true, nil
-}
-
-func parseIdentifiers(l *lexer, t token) (err error) {
-	for tkRparen != t && tkEOF != t {
-		if tkIdentifier != t {
-			return errors.New("expected identifier")
-		}
-		t = skipToken(l, l.next(), tkComma)
-	}
-	if tkRparen != t {
-		return errors.New("expected closing ')' for identifiers")
-	}
-	return nil
 }

--- a/parser/parse_insert_test.go
+++ b/parser/parse_insert_test.go
@@ -1,0 +1,41 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIdempotentInsertStmt(t *testing.T) {
+	var tests = []struct {
+		query      string
+		idempotent bool
+		hasError   bool
+		msg        string
+	}{
+		{"INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1)", true, false, "simple"},
+		{"INSERT INTO ks.table (a, b, c) VALUES (1, 'a', 0.1)", true, false, "simple qualified table name"},
+		// Invalid
+		{"INSERT table (a, b, c) VALUES (1, 'a', 0.1)", false, true, "missing 'INTO'"},
+		{"INSERT INTO (a, b, c) VALUES (1, 'a', 0.1)", false, true, "missing table name"},
+		{"INSERT INTO table a, b, c) VALUES (1, 'a', 0.1)", false, true, "missing opening paren. on identifiers"},
+		{"INSERT INTO table (a, b, c VALUES (1, 'a', 0.1)", false, true, "missing closing paren on identifiers"},
+		{"INSERT INTO table (a, b, c) (1, 'a', 0.1)", false, true, "missing 'VALUES'"},
+		{"INSERT INTO table (0, b, c) VALUES (1, 'a', 0.1)", false, true, "unexpected term in identifiers"},
+		{"INSERT INTO table (a, b, c) VALUES (invalid, 'a', 0.1)", false, true, "invalid value"},
+		{"INSERT INTO table (a, b, c) VALUES 1, 'a', 0.1)", false, true, "missing opening paren. on values"},
+		{"INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1", false, true, "missing closing paren. on values"},
+		{"INSERT INTO table () VALUES ()", true, false, "no identifier of values"},
+		// Not idempotent
+		{"INSERT INTO table (a, b, c) VALUES (now(), 'a', 0.1)", false, false, "simple w/ 'now()'"},
+		{"INSERT INTO table (a, b, c) VALUES (0, uuid(), 0.1)", false, false, "simple w/ 'uuid()'"},
+		{"INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) IF NOT EXISTS", false, false, "simple w/ LWT"},
+		{"INSERT INTO table () VALUES () IF NOT EXIST", false, false, "no identifier of values w/ LWT"},
+	}
+
+	for _, tt := range tests {
+		idempotent, err := IsQueryIdempotent(tt.query)
+		assert.True(t, (err != nil) == tt.hasError, tt.msg)
+		assert.Equal(t, tt.idempotent, idempotent, "invalid idempotency", tt.msg)
+	}
+}

--- a/parser/parse_insert_test.go
+++ b/parser/parse_insert_test.go
@@ -15,6 +15,9 @@ func TestIsIdempotentInsertStmt(t *testing.T) {
 	}{
 		{"INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1)", true, false, "simple"},
 		{"INSERT INTO ks.table (a, b, c) VALUES (1, 'a', 0.1)", true, false, "simple qualified table name"},
+		{"INSERT INTO table () VALUES ()", true, false, "no identifier of values"},
+		{"INSERT INTO table JSON '{}'", true, false, "JSON"},
+
 		// Invalid
 		{"INSERT table (a, b, c) VALUES (1, 'a', 0.1)", false, true, "missing 'INTO'"},
 		{"INSERT INTO (a, b, c) VALUES (1, 'a', 0.1)", false, true, "missing table name"},
@@ -25,8 +28,7 @@ func TestIsIdempotentInsertStmt(t *testing.T) {
 		{"INSERT INTO table (a, b, c) VALUES (invalid, 'a', 0.1)", false, true, "invalid value"},
 		{"INSERT INTO table (a, b, c) VALUES 1, 'a', 0.1)", false, true, "missing opening paren. on values"},
 		{"INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1", false, true, "missing closing paren. on values"},
-		{"INSERT INTO table () VALUES ()", true, false, "no identifier of values"},
-		{"INSERT INTO table JSON '{}'", true, false, "JSON"},
+
 		// Not idempotent
 		{"INSERT INTO table (a, b, c) VALUES (now(), 'a', 0.1)", false, false, "simple w/ 'now()'"},
 		{"INSERT INTO table (a, b, c) VALUES (0, uuid(), 0.1)", false, false, "simple w/ 'uuid()'"},

--- a/parser/parse_insert_test.go
+++ b/parser/parse_insert_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package parser
 
 import (

--- a/parser/parse_insert_test.go
+++ b/parser/parse_insert_test.go
@@ -26,11 +26,13 @@ func TestIsIdempotentInsertStmt(t *testing.T) {
 		{"INSERT INTO table (a, b, c) VALUES 1, 'a', 0.1)", false, true, "missing opening paren. on values"},
 		{"INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1", false, true, "missing closing paren. on values"},
 		{"INSERT INTO table () VALUES ()", true, false, "no identifier of values"},
+		{"INSERT INTO table JSON '{}'", true, false, "JSON"},
 		// Not idempotent
 		{"INSERT INTO table (a, b, c) VALUES (now(), 'a', 0.1)", false, false, "simple w/ 'now()'"},
 		{"INSERT INTO table (a, b, c) VALUES (0, uuid(), 0.1)", false, false, "simple w/ 'uuid()'"},
 		{"INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) IF NOT EXISTS", false, false, "simple w/ LWT"},
 		{"INSERT INTO table () VALUES () IF NOT EXIST", false, false, "no identifier of values w/ LWT"},
+		{"INSERT INTO table JSON '{}' IF NOT EXIST", false, false, "'JSON' w/ LWT"},
 	}
 
 	for _, tt := range tests {

--- a/parser/parse_relation.go
+++ b/parser/parse_relation.go
@@ -1,0 +1,174 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import "errors"
+
+func parseWhereClause(l *lexer) (idempotent bool, t token, err error) {
+	for t = l.next(); tkIf != t && tkEOF != t; t = skipToken(l, l.next(), tkAnd) {
+		idempotent, err = parseRelation(l, t)
+		if !idempotent {
+			return idempotent, tkInvalid, err
+		}
+	}
+	return true, t, nil
+}
+
+func parseRelation(l *lexer, t token) (idempotent bool, err error) {
+	switch t {
+	case tkIdentifier:
+		switch t = l.next(); t {
+		case tkIdentifier:
+			if isUnreservedKeyword(l, t, "contains") { // identifier 'contains' 'key'? term
+				if t = l.next(); isUnreservedKeyword(l, t, "key") {
+					t = l.next()
+				}
+				if idempotent, _, err = parseTerm(l, t); !idempotent {
+					return idempotent, err
+				}
+
+			} else if isUnreservedKeyword(l, t, "like") { // identifier 'like' term
+				if idempotent, _, err = parseTerm(l, l.next()); !idempotent {
+					return idempotent, err
+				}
+			} else {
+				return false, errors.New("unexpected token parsing relation")
+			}
+		case tkEqual, tkRangle, tkLtEqual, tkLangle, tkGtEqual, tkNotEqual: // identifier operator term
+			if idempotent, _, err = parseTerm(l, l.next()); !idempotent {
+				return idempotent, err
+			}
+		case tkIs: // identifier 'is' 'not' 'null'
+			if t = l.next(); tkNot != t {
+				return false, errors.New("expected 'not' in relation after 'is'")
+			}
+			if t = l.next(); tkNull != t {
+				return false, errors.New("expected 'null' in relation after 'is not'")
+			}
+		case tkLsquare: // identifier '[' term ']' operator term
+			if idempotent, _, err = parseTerm(l, l.next()); !idempotent {
+				return idempotent, err
+			}
+			if t = l.next(); tkRsquare != t {
+				return false, errors.New("expected closing ']' after term in relation")
+			}
+			if t = l.next(); !isOperator(t) {
+				return false, errors.New("expected operator after term in relation")
+			}
+			if idempotent, _, err = parseTerm(l, l.next()); !idempotent {
+				return idempotent, err
+			}
+		case tkIn: // identifier 'in' ('(' terms? ')' | bindMarker)
+			switch t = l.next(); t {
+			case tkLparen:
+				for t = l.next(); tkRparen != t && tkEOF != t; t = skipToken(l, l.next(), tkComma) {
+					if idempotent, _, err = parseTerm(l, t); !idempotent {
+						return idempotent, err
+					}
+				}
+			case tkColon, tkQMark:
+				err = parseBindMarker(l, t)
+				if err != nil {
+					return false, err
+				}
+			default:
+				return false, errors.New("unexpected token for 'IN' relation")
+			}
+		default:
+			return false, errors.New("unexpected token parsing relation")
+		}
+	case tkToken: // token '(' identifiers ')' operator term
+		if t = l.next(); tkLparen != t {
+			return false, errors.New("expected '(' after 'token'")
+		}
+		err = parseIdentifiers(l, l.next())
+		if err != nil {
+			return false, err
+		}
+		if t = l.next(); !isOperator(t) {
+			return false, errors.New("expected operator after identifier list in relation")
+		}
+		if idempotent, _, err = parseTerm(l, l.next()); !idempotent {
+			return idempotent, err
+		}
+	case tkLparen: // '(' relation ')' | '(' identifiers ')' ...
+		l.mark()
+		maybeId, maybeCommaOrRparen := l.next(), l.next() // Peek a couple tokens to see if this is an identifier list
+		if tkIdentifier == maybeId && (maybeCommaOrRparen == tkComma || maybeCommaOrRparen == tkRparen) {
+			t = skipToken(l, maybeCommaOrRparen, tkComma)
+			err = parseIdentifiers(l, t)
+			if err != nil {
+				return false, err
+			}
+			return parseIdentifiersRelation(l)
+		} else {
+			l.rewind()
+			idempotent, err = parseRelation(l, l.next())
+			if !idempotent {
+				return idempotent, err
+			}
+			if tkRparen != l.next() {
+				return false, errors.New("expected closing ')' after parenthesized relation")
+			}
+		}
+	default:
+		return false, errors.New("unexpected token in relation")
+	}
+	return true, nil
+}
+
+func parseIdentifiersRelation(l *lexer) (idempotent bool, err error) {
+	switch t := l.next(); t {
+	case tkIn, tkEqual, tkLt, tkLtEqual, tkGt, tkGtEqual, tkNotEqual: // '(' identifiers ')' 'in' ... | '(' identifiers ')' operator ...
+		switch t = l.next(); t {
+		case tkColon, tkQMark:
+			err = parseBindMarker(l, t)
+			if err != nil {
+				return false, err
+			}
+		case tkLparen:
+			for t = l.next(); tkRparen != t && tkEOF != t; t = skipToken(l, l.next(), tkComma) {
+				if idempotent, _, err = parseTerm(l, t); !idempotent {
+					return idempotent, err
+				}
+			}
+			if tkRparen != t {
+				return false, errors.New("expected closing ')' in identifiers relation")
+			}
+		}
+	default:
+		return false, errors.New("unexpected token in identifiers relation")
+	}
+
+	return true, nil
+}
+
+func isOperator(t token) bool {
+	return tkEqual == t || tkLt == t || tkLtEqual == t || tkGt == t || tkGtEqual == t || tkNotEqual == t
+}
+
+func parseBindMarker(l *lexer, t token) error {
+	switch t {
+	case tkColon:
+		if tkIdentifier != l.next() {
+			return errors.New("expected identifier after ':' for named bind marker")
+		}
+	case tkQMark:
+		// Do nothing
+	default:
+		return errors.New("invalid bind marker")
+	}
+	return nil
+}

--- a/parser/parse_relation.go
+++ b/parser/parse_relation.go
@@ -19,6 +19,7 @@ import "errors"
 // Determine if where clause is idempotent for an UPDATE or DELETE mutation.
 //
 // whereClause: 'WHERE' relation ( 'AND' relation )*
+//
 func parseWhereClause(l *lexer) (idempotent bool, t token, err error) {
 	for t = l.next(); tkIf != t && tkEOF != t; t = skipToken(l, l.next(), tkAnd) {
 		idempotent, err = parseRelation(l, t)
@@ -95,6 +96,9 @@ func parseRelation(l *lexer, t token) (idempotent bool, err error) {
 						return idempotent, err
 					}
 				}
+				if tkRparen != t {
+					return false, errors.New("expected closing ')' after terms")
+				}
 			case tkColon, tkQMark:
 				err = parseBindMarker(l, t)
 				if err != nil {
@@ -146,9 +150,14 @@ func parseRelation(l *lexer, t token) (idempotent bool, err error) {
 	return true, nil
 }
 
+// Determines if identifiers relation is idempotent.
+//
+//  ... 'IN' ( '(' terms? ')' | bindMarker )
+//  ... operator ( '(' terms? ')' | bindMarker )
+//
 func parseIdentifiersRelation(l *lexer) (idempotent bool, err error) {
 	switch t := l.next(); t {
-	case tkIn, tkEqual, tkLt, tkLtEqual, tkGt, tkGtEqual, tkNotEqual: // '(' identifiers ')' 'IN' ... | '(' identifiers ')' operator ...
+	case tkIn, tkEqual, tkLt, tkLtEqual, tkGt, tkGtEqual, tkNotEqual:
 		switch t = l.next(); t {
 		case tkColon, tkQMark:
 			err = parseBindMarker(l, t)
@@ -164,6 +173,8 @@ func parseIdentifiersRelation(l *lexer) (idempotent bool, err error) {
 			if tkRparen != t {
 				return false, errors.New("expected closing ')' in identifiers relation")
 			}
+		default:
+			return false, errors.New("unexpected term token in identifiers relation")
 		}
 	default:
 		return false, errors.New("unexpected token in identifiers relation")
@@ -172,10 +183,11 @@ func parseIdentifiersRelation(l *lexer) (idempotent bool, err error) {
 	return true, nil
 }
 
-func isOperator(t token) bool {
-	return tkEqual == t || tkLt == t || tkLtEqual == t || tkGt == t || tkGtEqual == t || tkNotEqual == t
-}
-
+// Parses the remainder of a bind marker.
+//
+// bindMarker
+// : ':' identifier
+// | '?'
 func parseBindMarker(l *lexer, t token) error {
 	switch t {
 	case tkColon:
@@ -188,4 +200,8 @@ func parseBindMarker(l *lexer, t token) error {
 		return errors.New("invalid bind marker")
 	}
 	return nil
+}
+
+func isOperator(t token) bool {
+	return tkEqual == t || tkLt == t || tkLtEqual == t || tkGt == t || tkGtEqual == t || tkNotEqual == t
 }

--- a/parser/parse_relation_test.go
+++ b/parser/parse_relation_test.go
@@ -24,37 +24,61 @@ func TestParseRelation(t *testing.T) {
 	var tests = []struct {
 		relation   string
 		idempotent bool
-		err        error
+		hasError   bool
 		msg        string
 	}{
-		{"id > 0", true, nil, "simple operator relation"},
-		{"token (a, b, c) > (0, 1, 2)", true, nil, "'token' relation"},
-		{"id LIKE 'abc'", true, nil, "'like' relation"},
-		{"id IS NOT NULL", true, nil, "'is not null' relation"},
-		{"id CONTAINS 'abc'", true, nil, "'contains' relation"},
-		{"id CONTAINS KEY 'abc'", true, nil, "'contains key' relation"},
-		{"id[0] > 0", true, nil, "index collection w/ int relation"},
-		{"id['abc'] > 'def'", true, nil, "index collection w/string relation"},
-		{"id IN ?", true, nil, "'IN' w/ position bind marker relation "},
-		{"id IN :column", true, nil, "'IN' w/ named bind marker relation"},
-		{"((((id > 0))))", true, nil, "arbitrary number of parens"},
-		{"(id1, id2, id3) IN ()", true, nil, "list in empty"},
-		{"(id1, id2, id3) IN ?", true, nil, "list in positional bind marker"},
-		{"(id1, id2, id3) IN :named", true, nil, "list in named bind marker"},
-		{"(id1, id2, id3) IN (?, ?, :named)", true, nil, "list in list of bind markers"},
-		{"(id1, id2, id3) IN (('a', ?, 0), ('b', :named, 1))", true, nil, "list in list of tuples"},
-		{"(id1, id2, id3) > ?", true, nil, "list in positional bind marker"},
-		{"(id1, id2, id3) < :named", true, nil, "list in named bind marker"},
-		{"(id1, id2, id3) >= (?, ?, :named)", true, nil, "list in list of bind markers"},
-		{"(id1, id2, id3) <= (('a', ?, 0), ('b', :named, 1))", true, nil, "list in list of tuples"},
+		{"id > 0", true, false, "simple operator relation"},
+		{"token (a, b, c) > (0, 1, 2)", true, false, "'token' relation"},
+		{"id LIKE 'abc'", true, false, "'like' relation"},
+		{"id IS NOT NULL", true, false, "'is not null' relation"},
+		{"id CONTAINS 'abc'", true, false, "'contains' relation"},
+		{"id CONTAINS KEY 'abc'", true, false, "'contains key' relation"},
+		{"id[0] > 0", true, false, "index collection w/ int relation"},
+		{"id['abc'] > 'def'", true, false, "index collection w/string relation"},
+		{"id IN ?", true, false, "'IN' w/ position bind marker relation "},
+		{"id IN :column", true, false, "'IN' w/ named bind marker relation"},
+		{"id IN (0, 1, 2)", true, false, "'IN' w/ terms"},
+		{"((((id > 0))))", true, false, "arbitrary number of parens"},
+		{"(id1, id2, id3) IN ()", true, false, "list in empty"},
+		{"(id1, id2, id3) IN ?", true, false, "list in positional bind marker"},
+		{"(id1, id2, id3) IN :named", true, false, "list in named bind marker"},
+		{"(id1, id2, id3) IN (?, ?, :named)", true, false, "list in list of bind markers"},
+		{"(id1, id2, id3) IN (('a', ?, 0), ('b', :named, 1))", true, false, "list in list of tuples"},
+		{"(id1, id2, id3) > ?", true, false, "list in positional bind marker"},
+		{"(id1, id2, id3) < :named", true, false, "list in named bind marker"},
+		{"(id1, id2, id3) >= (?, ?, :named)", true, false, "list in list of bind markers"},
+		{"(id1, id2, id3) <= (('a', ?, 0), ('b', :named, 1))", true, false, "list in list of tuples"},
+
+		// Invalid
+		{"id >", false, true, "missing term"},
+		{"id == 0", false, true, "invalid operator"},
+		{"token a, b, c) > (0, 1, 2)", false, true, "invalid 'token' relation w/ missing identifiers opening paren"},
+		{"token (a, b, c > (0, 1, 2)", false, true, "invalid 'token' relation w/ missing identifiers closing paren"},
+		{"token (a, b, c) > (0, 1, 2", false, true, "invalid 'token' relation w/ missing tuple closing paren"},
+		{"id IS", false, true, "invalid 'is not null' relation"},
+		{"id CONTAINS", false, true, "invalid 'contains' relation w/ missing term"},
+		{"id CONTAINS KEY", false, true, " invalid 'contains key' relation w/ missing term"},
+		{"id[0 > 0", false, true, "invalid index collection w/ int relation w/ missing closing square bracket"},
+		{"id[0] >", false, true, "invalid index collection w/ int relation w/ missing term"},
+		{"id LIKE", false, true, "invalid 'like' relation w/ missing term"},
+		{"id IN", false, true, "invalid 'IN' relation w/ missing bind marker/term"},
+		{"id IN 0", false, true, "invalid 'IN' relation w/ unexpect term"},
+		{"id IN (", false, true, "invalid 'IN' relation w/ missing closing paren and empty"},
+		{"id IN ('a'", false, true, "invalid 'IN' relation w/ missing closing paren"},
+		{"(id1, id2)", false, true, "invalid identifiers w/ no operator"},
+		{"id1, id2) IN ()", false, true, "invalid identifiers w/ missing opening paren"},
+		{"(id1, id2 IN ()", false, true, "invalid identifiers w/ missing closing paren"},
+		{"(id1, id2) IN ('a', 1", false, true, "invalid identifiers w/ missing terms closing paren"},
+		{"(id1, id2) == ('a', 1)", false, true, "invalid identifiers w/ invalid operator"},
+
 		// Not idempotent
-		{"id > now()", false, nil, "simple operator relation w/ 'now()'"},
-		{"id LIKE now()", false, nil, "'like' relation w/ 'now()'"},
-		{"id CONTAINS now()", false, nil, "'contains' relation w/ 'now()'"},
-		{"id CONTAINS KEY now()", false, nil, "'contains key' relation w/ 'now()'"},
-		{"id1 IN (now(), uuid())", false, nil, "'in' relation w/ 'now()'"},
-		{"(id1, id2) IN (now(), uuid())", false, nil, "list 'IN' relation w/ 'now()'"},
-		{"(id1, id2) < (now(), uuid())", false, nil, "list operator reation w/ 'now()'"},
+		{"id > now()", false, false, "simple operator relation w/ 'now()'"},
+		{"id LIKE now()", false, false, "'like' relation w/ 'now()'"},
+		{"id CONTAINS now()", false, false, "'contains' relation w/ 'now()'"},
+		{"id CONTAINS KEY now()", false, false, "'contains key' relation w/ 'now()'"},
+		{"id1 IN (now(), uuid())", false, false, "'in' relation w/ 'now()'"},
+		{"(id1, id2) IN (now(), uuid())", false, false, "list 'IN' relation w/ 'now()'"},
+		{"(id1, id2) < (now(), uuid())", false, false, "list operator reation w/ 'now()'"},
 	}
 
 	for _, tt := range tests {
@@ -62,6 +86,6 @@ func TestParseRelation(t *testing.T) {
 		l.init(tt.relation)
 		idempotent, err := parseRelation(&l, l.next())
 		assert.Equal(t, tt.idempotent, idempotent, tt.msg)
-		assert.Equal(t, err, err, tt.msg)
+		assert.True(t, (err != nil) == tt.hasError, tt.msg)
 	}
 }

--- a/parser/parse_relation_test.go
+++ b/parser/parse_relation_test.go
@@ -47,6 +47,14 @@ func TestParseRelation(t *testing.T) {
 		{"(id1, id2, id3) < :named", true, nil, "list in named bind marker"},
 		{"(id1, id2, id3) >= (?, ?, :named)", true, nil, "list in list of bind markers"},
 		{"(id1, id2, id3) <= (('a', ?, 0), ('b', :named, 1))", true, nil, "list in list of tuples"},
+		// Not idempotent
+		{"id > now()", false, nil, "simple operator relation w/ 'now()'"},
+		{"id LIKE now()", false, nil, "'like' relation w/ 'now()'"},
+		{"id CONTAINS now()", false, nil, "'contains' relation w/ 'now()'"},
+		{"id CONTAINS KEY now()", false, nil, "'contains key' relation w/ 'now()'"},
+		{"id1 IN (now(), uuid())", false, nil, "'in' relation w/ 'now()'"},
+		{"(id1, id2) IN (now(), uuid())", false, nil, "list 'IN' relation w/ 'now()'"},
+		{"(id1, id2) < (now(), uuid())", false, nil, "list operator reation w/ 'now()'"},
 	}
 
 	for _, tt := range tests {

--- a/parser/parse_relation_test.go
+++ b/parser/parse_relation_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRelation(t *testing.T) {
+	var tests = []struct {
+		relation   string
+		idempotent bool
+		err        error
+		msg        string
+	}{
+		{"id > 0", true, nil, "simple operator relation"},
+		{"token (a, b, c) > (0, 1, 2)", true, nil, "'token' relation"},
+		{"id LIKE 'abc'", true, nil, "'like' relation"},
+		{"id IS NOT NULL", true, nil, "'is not null' relation"},
+		{"id CONTAINS 'abc'", true, nil, "'contains' relation"},
+		{"id CONTAINS KEY 'abc'", true, nil, "'contains key' relation"},
+		{"id[0] > 0", true, nil, "index collection w/ int relation"},
+		{"id['abc'] > 'def'", true, nil, "index collection w/string relation"},
+		{"id IN ?", true, nil, "'IN' w/ position bind marker relation "},
+		{"id IN :column", true, nil, "'IN' w/ named bind marker relation"},
+		{"((((id > 0))))", true, nil, "arbitrary number of parens"},
+		{"(id1, id2, id3) IN ()", true, nil, "list in empty"},
+		{"(id1, id2, id3) IN ?", true, nil, "list in positional bind marker"},
+		{"(id1, id2, id3) IN :named", true, nil, "list in named bind marker"},
+		{"(id1, id2, id3) IN (?, ?, :named)", true, nil, "list in list of bind markers"},
+		{"(id1, id2, id3) IN (('a', ?, 0), ('b', :named, 1))", true, nil, "list in list of tuples"},
+		{"(id1, id2, id3) > ?", true, nil, "list in positional bind marker"},
+		{"(id1, id2, id3) < :named", true, nil, "list in named bind marker"},
+		{"(id1, id2, id3) >= (?, ?, :named)", true, nil, "list in list of bind markers"},
+		{"(id1, id2, id3) <= (('a', ?, 0), ('b', :named, 1))", true, nil, "list in list of tuples"},
+	}
+
+	for _, tt := range tests {
+		var l lexer
+		l.init(tt.relation)
+		idempotent, err := parseRelation(&l, l.next())
+		assert.Equal(t, tt.idempotent, idempotent, tt.msg)
+		assert.Equal(t, err, err, tt.msg)
+	}
+}

--- a/parser/parse_term.go
+++ b/parser/parse_term.go
@@ -1,0 +1,150 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"errors"
+)
+
+type termType int
+
+const (
+	termInvalid        termType = iota
+	termIntegerLiteral          // Special because it can be used to index lists for deletes
+	termPrimitiveLiteral
+	termListLiteral
+	termSetMapUdtLiteral // All use curly, distinction not important
+	termTupleLiteral
+	termBindMarker
+	termFunctionCall
+	termCast
+)
+
+func parseType(l *lexer) (t token, err error) {
+	if t = l.next(); tkLangle == t {
+		for t = l.next(); tkRangle != t && tkEOF != t; t = skipToken(l, l.next(), tkComma) {
+			if t != tkIdentifier {
+				return tkInvalid, errors.New("expected sub-type in type parameter")
+			}
+		}
+		if tkRangle != t {
+			return tkInvalid, errors.New("expected closing '>' bracket for type")
+		}
+		return l.next(), nil
+	}
+	return t, nil
+}
+
+func parseTerm(l *lexer, t token) (idempotent bool, typ termType, err error) {
+	switch t {
+	case tkInteger:
+		return true, termIntegerLiteral, nil
+	case tkFloat, tkBool, tkNull, tkStringLiteral, tkHexNumber, tkUuid, tkDuration, tkNan, tkInfinity: // Literal
+		return true, termPrimitiveLiteral, nil
+	case tkLsquare: // List literal
+		for t = l.next(); t != tkRsquare && t != tkEOF; t = skipToken(l, l.next(), tkComma) {
+			if idempotent, _, err = parseTerm(l, t); !idempotent {
+				return idempotent, termInvalid, err
+			}
+		}
+		if t != tkRsquare {
+			return false, termInvalid, errors.New("expected closing ']' bracket for list literal")
+		}
+		return true, termListLiteral, nil
+	case tkLcurly: // Set, map, or UDT literal
+		if t = l.next(); t == tkIdentifier { // UDT
+			for t != tkRcurly && t != tkEOF {
+				_, _, t, err = parseQualifiedIdentifier(l)
+				if err != nil {
+					return false, termInvalid, err
+				}
+				t = skipToken(l, l.next(), tkColon)
+				if idempotent, typ, err = parseTerm(l, t); !idempotent {
+					return idempotent, termInvalid, err
+				}
+				t = skipToken(l, l.next(), tkComma)
+			}
+		} else {
+			for t != tkRcurly && t != tkEOF {
+				if idempotent, typ, err = parseTerm(l, t); !idempotent {
+					return idempotent, termInvalid, err
+				}
+				if t = l.next(); tkColon == t { // Map
+					if idempotent, typ, err = parseTerm(l, l.next()); !idempotent {
+						return idempotent, termInvalid, err
+					}
+					t = l.next()
+				}
+				t = skipToken(l, t, tkComma)
+			}
+		}
+		if t != tkRcurly {
+			return false, termInvalid, errors.New("expected closing '}' bracket for set/map/UDT literal")
+		}
+		return true, termSetMapUdtLiteral, nil
+	case tkLparen: // Type cast or tuple literal
+		if t = l.next(); t == tkIdentifier { // Cast
+			t, err = parseType(l)
+			if err != nil {
+				return false, termInvalid, err
+			}
+			if t != tkRparen {
+				return false, termInvalid, errors.New("expected closing ')' bracket for type cast")
+			}
+			if idempotent, typ, err = parseTerm(l, l.next()); !idempotent {
+				return idempotent, termInvalid, err
+			}
+			return true, termCast, err
+		} else { // Tuple literal
+			for t != tkRparen && t != tkEOF {
+				if idempotent, _, err = parseTerm(l, t); !idempotent {
+					return idempotent, termInvalid, err
+				}
+				t = skipToken(l, l.next(), tkComma)
+			}
+			if t != tkRparen {
+				return false, termInvalid, errors.New("expected closing ')' bracket for tuple literal")
+			}
+			return true, termTupleLiteral, nil
+		}
+	case tkColon: // Named bind marker
+		if t = l.next(); t != tkIdentifier {
+			return false, termInvalid, errors.New("expected identifier after ':' for named bind marker")
+		}
+		return true, termBindMarker, nil
+	case tkQMark: // Positional bind marker
+		return true, termBindMarker, nil
+	case tkIdentifier: // Function
+		var target, keyspace Identifier
+		keyspace, target, t, err = parseQualifiedIdentifier(l)
+		if err != nil {
+			return false, termInvalid, err
+		}
+		if tkLparen != t {
+			return false, termInvalid, errors.New("invalid term, was expecting function call")
+		}
+		for t = l.next(); t != tkRparen && t != tkEOF; t = skipToken(l, l.next(), tkComma) {
+			if idempotent, _, err = parseTerm(l, t); !idempotent {
+				return idempotent, termInvalid, err
+			}
+		}
+		if t != tkRparen {
+			return false, termInvalid, errors.New("expected closing ')' for function call")
+		}
+		return !(isNonIdempotentFunc(target) && (keyspace.isEmpty() || keyspace.equal("system"))), termFunctionCall, nil
+	}
+
+	return false, termInvalid, errors.New("invalid term")
+}

--- a/parser/parse_term.go
+++ b/parser/parse_term.go
@@ -32,6 +32,183 @@ const (
 	termCast
 )
 
+// Determines if a term is idempotent and also returns the top-level type of the term.
+//
+// A term is not idempotent if it contains a non-idempotent function e.g. 'now()' or 'uuid()'
+//
+// term: literal | bindMarker | functionCall | typeCast
+//
+// literal: primitiveLiteral | collectionLiteral | tupleLiteral | udtLiteral | 'NULL'
+// primitiveLiteral:  stringLiteral | integer | float | boolean | duration | uuid | hexNumber | '-'? 'NAN' | '-'? 'INFINITY'
+// collectionLiteral: listLiteral | setLiteral | mapLiteral
+// listLiteral: '[' terms? ']'
+// setLiteral: '{' terms? '}'
+// mapLiteral: '{' ( mapEntry ( ',' mapEntry )* )? '}'
+// mapEntry: term ':' term
+// tupleLiteral: '(' terms? ')'
+// udtLiteral: '{' ( fieldEntry ( ',' fieldEntry )* )? '}'
+// fieldEntry: identifier ':' term
+//
+// bindMarker: '?' | ':' identifier
+//
+// functionCall: ( identifier '.' )? identifier '(' functionArg ( ',' functionArg )* ')'
+// functionArg: identifier | term
+//
+// typeCast: '(' type ')' term
+// type: identifier | identifier '<' type '>'
+//
+func parseTerm(l *lexer, t token) (idempotent bool, typ termType, err error) {
+	switch t {
+	case tkInteger: // Integer lister
+		return true, termIntegerLiteral, nil
+	case tkFloat, tkBool, tkNull, tkStringLiteral, tkHexNumber, tkUuid, tkDuration, tkNan, tkInfinity: // Literal
+		return true, termPrimitiveLiteral, nil
+	case tkColon: // Named bind marker
+		if t = l.next(); t != tkIdentifier {
+			return false, termBindMarker, errors.New("expected identifier after ':' for named bind marker")
+		}
+		return true, termBindMarker, nil
+	case tkQMark: // Positional bind marker
+		return true, termBindMarker, nil
+	case tkLsquare: // List literal
+		return parseListTerm(l)
+	case tkLcurly: // Set, map, or UDT literal
+		if t = l.next(); t == tkIdentifier { // maybe UDT
+			l.mark()
+			var maybeColon token
+			_, _, maybeColon, err = parseQualifiedIdentifier(l)
+			if err != nil {
+				return false, termSetMapUdtLiteral, err
+			}
+			l.rewind()
+			if tkColon == maybeColon { // UDT
+				return parseUDTTerm(l, t)
+			} else { // Set or map (probably starting with a function)
+				return parseSetOrMapTerm(l, t)
+			}
+		} else { // Set or map
+			return parseSetOrMapTerm(l, t)
+		}
+	case tkLparen: // Type cast or tuple literal
+		if t = l.next(); t == tkIdentifier { // Cast
+			return parseCastTerm(l, t)
+		} else { // Tuple literal
+			return parseTupleTerm(l, t)
+		}
+	case tkIdentifier: // Function
+		return parseFunctionTerm(l)
+	}
+
+	return false, termInvalid, errors.New("invalid term")
+}
+
+func parseListTerm(l *lexer) (idempotent bool, typ termType, err error) {
+	var t token
+	for t = l.next(); t != tkRsquare && t != tkEOF; t = skipToken(l, l.next(), tkComma) {
+		if idempotent, _, err = parseTerm(l, t); !idempotent {
+			return idempotent, termListLiteral, err
+		}
+	}
+	if t != tkRsquare {
+		return false, termListLiteral, errors.New("expected closing ']' bracket for list literal")
+	}
+	return true, termListLiteral, nil
+}
+
+func parseUDTTerm(l *lexer, t token) (idempotent bool, typ termType, err error) {
+	for t != tkRcurly && t != tkEOF {
+		if tkIdentifier != t {
+			return false, termSetMapUdtLiteral, errors.New("expected identifier in UDT literal field")
+		}
+		_, _, t, err = parseQualifiedIdentifier(l)
+		if err != nil {
+			return false, termSetMapUdtLiteral, err
+		}
+		t = skipToken(l, l.next(), tkColon)
+		if idempotent, typ, err = parseTerm(l, t); !idempotent {
+			return idempotent, termSetMapUdtLiteral, err
+		}
+		t = skipToken(l, l.next(), tkComma)
+	}
+	if t != tkRcurly {
+		return false, termSetMapUdtLiteral, errors.New("expected closing '}' bracket for UDT literal")
+	}
+	return true, termSetMapUdtLiteral, nil
+}
+
+func parseSetOrMapTerm(l *lexer, t token) (idempotent bool, typ termType, err error) {
+	for t != tkRcurly && t != tkEOF {
+		if idempotent, typ, err = parseTerm(l, t); !idempotent {
+			return idempotent, termSetMapUdtLiteral, err
+		}
+		if t = l.next(); tkColon == t { // Map
+			if idempotent, typ, err = parseTerm(l, l.next()); !idempotent {
+				return idempotent, termSetMapUdtLiteral, err
+			}
+			t = l.next()
+		}
+		t = skipToken(l, t, tkComma)
+	}
+	if t != tkRcurly {
+		return false, termSetMapUdtLiteral, errors.New("expected closing '}' bracket for set/map literal")
+	}
+	return true, termSetMapUdtLiteral, nil
+}
+
+func parseCastTerm(l *lexer, t token) (idempotent bool, typ termType, err error) {
+	t, err = parseType(l)
+	if err != nil {
+		return false, termCast, err
+	}
+	if t != tkRparen {
+		return false, termCast, errors.New("expected closing ')' bracket for type cast")
+	}
+	if idempotent, typ, err = parseTerm(l, l.next()); !idempotent {
+		return idempotent, termCast, err
+	}
+	return true, termCast, err
+}
+
+func parseTupleTerm(l *lexer, t token) (idempotent bool, typ termType, err error) {
+	for t != tkRparen && t != tkEOF {
+		if idempotent, _, err = parseTerm(l, t); !idempotent {
+			return idempotent, termTupleLiteral, err
+		}
+		t = skipToken(l, l.next(), tkComma)
+	}
+	if t != tkRparen {
+		return false, termTupleLiteral, errors.New("expected closing ')' bracket for tuple literal")
+	}
+	return true, termTupleLiteral, nil
+}
+
+func parseFunctionTerm(l *lexer) (idempotent bool, typ termType, err error) {
+	var target, keyspace Identifier
+	keyspace, target, t, err := parseQualifiedIdentifier(l)
+	if err != nil {
+		return false, termFunctionCall, err
+	}
+	if tkLparen != t {
+		return false, termFunctionCall, errors.New("invalid term, was expecting function call")
+	}
+	for t = l.next(); t != tkRparen && t != tkEOF; t = skipToken(l, l.next(), tkComma) {
+		l.mark()
+		maybeCommaOrRparen := l.next()
+		if tkIdentifier == t && (tkComma == maybeCommaOrRparen || tkRparen == maybeCommaOrRparen) {
+			l.rewind()
+		} else {
+			l.rewind()
+			if idempotent, _, err = parseTerm(l, t); !idempotent {
+				return idempotent, termFunctionCall, err
+			}
+		}
+	}
+	if t != tkRparen {
+		return false, termFunctionCall, errors.New("expected closing ')' for function call")
+	}
+	return !(isNonIdempotentFunc(target) && (keyspace.isEmpty() || keyspace.equal("system"))), termFunctionCall, nil
+}
+
 func parseType(l *lexer) (t token, err error) {
 	if t = l.next(); tkLangle == t {
 		for t = l.next(); tkRangle != t && tkEOF != t; t = skipToken(l, l.next(), tkComma) {
@@ -45,106 +222,4 @@ func parseType(l *lexer) (t token, err error) {
 		return l.next(), nil
 	}
 	return t, nil
-}
-
-func parseTerm(l *lexer, t token) (idempotent bool, typ termType, err error) {
-	switch t {
-	case tkInteger:
-		return true, termIntegerLiteral, nil
-	case tkFloat, tkBool, tkNull, tkStringLiteral, tkHexNumber, tkUuid, tkDuration, tkNan, tkInfinity: // Literal
-		return true, termPrimitiveLiteral, nil
-	case tkLsquare: // List literal
-		for t = l.next(); t != tkRsquare && t != tkEOF; t = skipToken(l, l.next(), tkComma) {
-			if idempotent, _, err = parseTerm(l, t); !idempotent {
-				return idempotent, termInvalid, err
-			}
-		}
-		if t != tkRsquare {
-			return false, termInvalid, errors.New("expected closing ']' bracket for list literal")
-		}
-		return true, termListLiteral, nil
-	case tkLcurly: // Set, map, or UDT literal
-		if t = l.next(); t == tkIdentifier { // UDT
-			for t != tkRcurly && t != tkEOF {
-				_, _, t, err = parseQualifiedIdentifier(l)
-				if err != nil {
-					return false, termInvalid, err
-				}
-				t = skipToken(l, l.next(), tkColon)
-				if idempotent, typ, err = parseTerm(l, t); !idempotent {
-					return idempotent, termInvalid, err
-				}
-				t = skipToken(l, l.next(), tkComma)
-			}
-		} else {
-			for t != tkRcurly && t != tkEOF {
-				if idempotent, typ, err = parseTerm(l, t); !idempotent {
-					return idempotent, termInvalid, err
-				}
-				if t = l.next(); tkColon == t { // Map
-					if idempotent, typ, err = parseTerm(l, l.next()); !idempotent {
-						return idempotent, termInvalid, err
-					}
-					t = l.next()
-				}
-				t = skipToken(l, t, tkComma)
-			}
-		}
-		if t != tkRcurly {
-			return false, termInvalid, errors.New("expected closing '}' bracket for set/map/UDT literal")
-		}
-		return true, termSetMapUdtLiteral, nil
-	case tkLparen: // Type cast or tuple literal
-		if t = l.next(); t == tkIdentifier { // Cast
-			t, err = parseType(l)
-			if err != nil {
-				return false, termInvalid, err
-			}
-			if t != tkRparen {
-				return false, termInvalid, errors.New("expected closing ')' bracket for type cast")
-			}
-			if idempotent, typ, err = parseTerm(l, l.next()); !idempotent {
-				return idempotent, termInvalid, err
-			}
-			return true, termCast, err
-		} else { // Tuple literal
-			for t != tkRparen && t != tkEOF {
-				if idempotent, _, err = parseTerm(l, t); !idempotent {
-					return idempotent, termInvalid, err
-				}
-				t = skipToken(l, l.next(), tkComma)
-			}
-			if t != tkRparen {
-				return false, termInvalid, errors.New("expected closing ')' bracket for tuple literal")
-			}
-			return true, termTupleLiteral, nil
-		}
-	case tkColon: // Named bind marker
-		if t = l.next(); t != tkIdentifier {
-			return false, termInvalid, errors.New("expected identifier after ':' for named bind marker")
-		}
-		return true, termBindMarker, nil
-	case tkQMark: // Positional bind marker
-		return true, termBindMarker, nil
-	case tkIdentifier: // Function
-		var target, keyspace Identifier
-		keyspace, target, t, err = parseQualifiedIdentifier(l)
-		if err != nil {
-			return false, termInvalid, err
-		}
-		if tkLparen != t {
-			return false, termInvalid, errors.New("invalid term, was expecting function call")
-		}
-		for t = l.next(); t != tkRparen && t != tkEOF; t = skipToken(l, l.next(), tkComma) {
-			if idempotent, _, err = parseTerm(l, t); !idempotent {
-				return idempotent, termInvalid, err
-			}
-		}
-		if t != tkRparen {
-			return false, termInvalid, errors.New("expected closing ')' for function call")
-		}
-		return !(isNonIdempotentFunc(target) && (keyspace.isEmpty() || keyspace.equal("system"))), termFunctionCall, nil
-	}
-
-	return false, termInvalid, errors.New("invalid term")
 }

--- a/parser/parse_term_test.go
+++ b/parser/parse_term_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTerm(t *testing.T) {
+	var tests = []struct {
+		term       string
+		idempotent bool
+		typ        termType
+		err        error
+		msg        string
+	}{
+		{"system.now()", false, termFunctionCall, nil, "qualified 'now()' function"},
+		{"system.uuid()", false, termFunctionCall, nil, "qualified 'uuid()' function "},
+		{"system.someOtherFunc()", true, termFunctionCall, nil, "qualified idempotent function"},
+		{"[1, 2, 3]", true, termListLiteral, nil, "list literal"},
+		{"[now(), 2, 3]", false, termInvalid, nil, "list literal with 'now()' function"},
+		{"123", true, termIntegerLiteral, nil, "integer literal"},
+		{"{1, 2, 3}", true, termSetMapUdtLiteral, nil, "set literal"},
+		{"{ a: 1, a.b: 2, c: 3}", true, termSetMapUdtLiteral, nil, "UDT literal"},
+		{"{ 'a': 1, 'b': 2, 'c': 3}", true, termSetMapUdtLiteral, nil, "map literal"},
+		{"(1, 'a', [])", true, termTupleLiteral, nil, "tuple literal"},
+		{":abc", true, termBindMarker, nil, "named bind marker"},
+		{"?", true, termBindMarker, nil, "positional bind marker"},
+		{"(map<int, text>)1", true, termCast, nil, "cast to a complex type"},
+		{"(uuid)now()", false, termInvalid, nil, "cast of the 'now()' function"},
+	}
+
+	for _, tt := range tests {
+		var l lexer
+		l.init(tt.term)
+		idempotent, typ, err := parseTerm(&l, l.next())
+		assert.Equal(t, tt.idempotent, idempotent, tt.msg)
+		assert.Equal(t, tt.typ, typ, tt.msg)
+		assert.Equal(t, err, err, tt.msg)
+	}
+}

--- a/parser/parse_term_test.go
+++ b/parser/parse_term_test.go
@@ -25,27 +25,37 @@ func TestParseTerm(t *testing.T) {
 		term       string
 		idempotent bool
 		typ        termType
-		err        error
+		hasError   bool
 		msg        string
 	}{
-		{"system.someOtherFunc()", true, termFunctionCall, nil, "qualified idempotent function"},
-		{"[1, 2, 3]", true, termListLiteral, nil, "list literal"},
-		{"123", true, termIntegerLiteral, nil, "integer literal"},
-		{"{1, 2, 3}", true, termSetMapUdtLiteral, nil, "set literal"},
-		{"{ a: 1, a.b: 2, c: 3}", true, termSetMapUdtLiteral, nil, "UDT literal"},
-		{"{ 'a': 1, 'b': 2, 'c': 3}", true, termSetMapUdtLiteral, nil, "map literal"},
-		{"(1, 'a', [])", true, termTupleLiteral, nil, "tuple literal"},
-		{":abc", true, termBindMarker, nil, "named bind marker"},
-		{"?", true, termBindMarker, nil, "positional bind marker"},
-		{"(map<int, text>)1", true, termCast, nil, "cast to a complex type"},
-		{"func(a, b, c)", true, termFunctionCall, nil, "function with identifier args"},
+		{"system.someOtherFunc()", true, termFunctionCall, false, "qualified idempotent function"},
+		{"[1, 2, 3]", true, termListLiteral, false, "list literal"},
+		{"123", true, termIntegerLiteral, false, "integer literal"},
+		{"{1, 2, 3}", true, termSetMapUdtLiteral, false, "set literal"},
+		{"{ a: 1, a.b: 2, c: 3}", true, termSetMapUdtLiteral, false, "UDT literal"},
+		{"{ 'a': 1, 'b': 2, 'c': 3}", true, termSetMapUdtLiteral, false, "map literal"},
+		{"(1, 'a', [])", true, termTupleLiteral, false, "tuple literal"},
+		{":abc", true, termBindMarker, false, "named bind marker"},
+		{"?", true, termBindMarker, false, "positional bind marker"},
+		{"(map<int, text>)1", true, termCast, false, "cast to a complex type"},
+		{"func(a, b, c)", true, termFunctionCall, false, "function with identifier args"},
+
+		// Invalid
+		{"system.someOtherFunc", false, termFunctionCall, true, "invalid qualified function"},
+		{"func", false, termFunctionCall, true, "invalid function"},
+		{"[1, 2, 3", false, termListLiteral, true, "invalid list literal"},
+		{"{1, 2, 3", false, termSetMapUdtLiteral, true, "invalid set literal"},
+		{"{ a: 1, a.b: 2, c: 3", false, termSetMapUdtLiteral, true, "invalid UDT literal"},
+		{"{ 'a': 1, 'b': 2, 'c': 3", false, termSetMapUdtLiteral, true, "invalid map literal"},
+		{"+123", false, termInvalid, true, "invalid term"},
+
 		// Not idempotent
-		{"system.now()", false, termFunctionCall, nil, "qualified 'now()' function"},
-		{"system.uuid()", false, termFunctionCall, nil, "qualified 'uuid()' function "},
-		{"(uuid)now()", false, termCast, nil, "cast of the 'now()' function"},
-		{"now(a, b, c, '1', 0)", false, termFunctionCall, nil, "'now()' function w/ args"},
-		{"[now(), 2, 3]", false, termListLiteral, nil, "list literal with 'now()' function"},
-		{"{now():'a'}", false, termSetMapUdtLiteral, nil, "map literal with 'now()' function"},
+		{"system.now()", false, termFunctionCall, false, "qualified 'now()' function"},
+		{"system.uuid()", false, termFunctionCall, false, "qualified 'uuid()' function "},
+		{"(uuid)now()", false, termCast, false, "cast of the 'now()' function"},
+		{"now(a, b, c, '1', 0)", false, termFunctionCall, false, "'now()' function w/ args"},
+		{"[now(), 2, 3]", false, termListLiteral, false, "list literal with 'now()' function"},
+		{"{now():'a'}", false, termSetMapUdtLiteral, false, "map literal with 'now()' function"},
 	}
 
 	for _, tt := range tests {
@@ -54,6 +64,6 @@ func TestParseTerm(t *testing.T) {
 		idempotent, typ, err := parseTerm(&l, l.next())
 		assert.Equal(t, tt.idempotent, idempotent, tt.msg)
 		assert.Equal(t, tt.typ, typ, tt.msg)
-		assert.Equal(t, err, err, tt.msg)
+		assert.True(t, (err != nil) == tt.hasError, tt.msg)
 	}
 }

--- a/parser/parse_update.go
+++ b/parser/parse_update.go
@@ -18,6 +18,11 @@ import "errors"
 
 // Determines if an update statement is idempotent.
 //
+// An update statement not idempotent if:
+// * it contains an update operation that appends/prepends to a list or updates a counter
+// * uses a lightweight transaction (LWT) e.g. 'IF EXISTS' or 'IF a > 0'
+// * has an update operation or relation that uses a non-idempotent function e.g. now() or uuid()
+//
 // updateStatement: 'UPDATE' tableName usingClause? 'SET' updateOperations whereClause( 'IF' ( 'EXISTS' | conditions ))?
 // tableName: ( identifier '.' )? identifier
 //
@@ -85,6 +90,7 @@ func parseUsingClause(l *lexer, t token) (next token, err error) {
 			if err != nil {
 				return tkInvalid, err
 			}
+			return l.next(), nil
 		}
 	}
 	return t, nil

--- a/parser/parse_update.go
+++ b/parser/parse_update.go
@@ -16,6 +16,11 @@ package parser
 
 import "errors"
 
+// Determines if an update statement is idempotent.
+//
+// updateStatement: 'UPDATE' tableName usingClause? 'SET' updateOperations whereClause( 'IF' ( 'EXISTS' | conditions ))?
+// tableName: ( identifier '.' )? identifier
+//
 func isIdempotentUpdateStmt(l *lexer) (idempotent bool, err error) {
 	t := l.next()
 	if tkIdentifier != t {
@@ -61,6 +66,14 @@ func isIdempotentUpdateStmt(l *lexer) (idempotent bool, err error) {
 	return true, nil
 }
 
+// Parse over using clause.
+//
+// usingClause
+//	  : 'USING' timestamp
+//    | 'USING' ttl
+//    | 'USING' timestamp 'AND' ttl
+//    | 'USING' ttl 'AND' timestamp
+//
 func parseUsingClause(l *lexer, t token) (next token, err error) {
 	if tkUsing == t {
 		err = parseTtlOrTimestamp(l)
@@ -77,6 +90,11 @@ func parseUsingClause(l *lexer, t token) (next token, err error) {
 	return t, nil
 }
 
+// Parse over TTL or timestamp
+//
+// timestamp: 'TIMESTAMP' ( INTEGER | bindMarker )
+// ttl: 'TTL' ( INTEGER | bindMarker )
+//
 func parseTtlOrTimestamp(l *lexer) error {
 	var t token
 	if t = l.next(); !isUnreservedKeyword(l, t, "ttl") && !isUnreservedKeyword(l, t, "timestamp") {

--- a/parser/parse_update_test.go
+++ b/parser/parse_update_test.go
@@ -1,0 +1,1 @@
+package parser

--- a/parser/parse_update_test.go
+++ b/parser/parse_update_test.go
@@ -1,1 +1,63 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIdempotentUpdateStmt(t *testing.T) {
+	var tests = []struct {
+		query      string
+		idempotent bool
+		hasError   bool
+		msg        string
+	}{
+		{"UPDATE table SET a = 0", true, false, "simple table"},
+		{"UPDATE table SET a = 0, b = 0", true, false, "multiple updates"},
+		{"UPDATE ks.table SET a = 0", true, false, "simple qualified table"},
+		{"UPDATE ks.table USING TIMESTAMP 1234 SET a = 0", true, false, "using timestamp"},
+		{"UPDATE ks.table USING TIMESTAMP 1234 AND TTL 5678 SET a = 0", true, false, "using timestamp and ttl"},
+		{"UPDATE ks.table USING TTL 1234 SET a = 0", true, false, "using ttl"},
+		{"UPDATE ks.table USING TTL 1234 AND TIMESTAMP 5678 SET a = 0", true, false, "using ttl and timestamp"},
+		{"UPDATE ks.table SET a = 0 WHERE a > 100", true, false, "where clause"},
+
+		// Invalid
+		{"UPDATE table", false, true, "no 'SET'"},
+		{"UPDATE table a = 0", false, true, "no 'SET' w/ update operation"},
+		{"UPDATE table a = 0 WHERE", false, true, "where clause no relations"},
+		{"UPDATE table SET a = 0,", true, false, "multiple updates no operation"},
+		{"UPDATE ks. SET a = 0", false, true, "no table"},
+		{"UPDATE table USING SET a = 0", false, true, "no timestamp or ttl"},
+		{"UPDATE table USING TTL SET a = 0", false, true, "ttl no value"},
+		{"UPDATE table USING TTL 1234 AND SET a = 0", false, true, "no ttl/timestamp after 'AND' in using clause"},
+
+		// Not idempotent
+		{"UPDATE table SET a = now()", false, false, "simple w/ now()"},
+		{"UPDATE table SET a = a + 1", false, false, "add to counter"},
+		{"UPDATE table USING TIMESTAMP 1234 SET a = now()", false, false, "using clause w/ now()"},
+		{"UPDATE table SET a = 0 WHERE a > toTimestamp(toDate(now()))", false, false, "where clause w/ now()"},
+		{"UPDATE table SET a = 0 WHERE a > 0 IF EXISTS", false, false, "where clause w/ LWT"},
+		{"UPDATE table SET a = 0 IF EXISTS", false, false, "LWT"},
+	}
+
+	for _, tt := range tests {
+		idempotent, err := IsQueryIdempotent(tt.query)
+		assert.True(t, (err != nil) == tt.hasError, tt.msg)
+		assert.Equal(t, tt.idempotent, idempotent, "invalid idempotency", tt.msg)
+	}
+}

--- a/parser/parse_updateop.go
+++ b/parser/parse_updateop.go
@@ -1,0 +1,103 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import "errors"
+
+func parseUpdateOp(l *lexer, t token) (idempotent bool, err error) {
+	if tkIdentifier != t {
+		return false, errors.New("expected identifier after 'SET' in update statement")
+	}
+
+	var typ termType
+
+	switch t = l.next(); t {
+	case tkEqual:
+		l.mark()
+		maybeId, maybeAddOrSub := l.next(), l.next()
+		if tkIdentifier == maybeId && (tkAdd == maybeAddOrSub || tkSub == maybeAddOrSub) { // identifier = identifier + term | identifier = identifier - term
+			t = l.next()
+			if idempotent, typ, err = parseTerm(l, t); !idempotent {
+				return idempotent, err
+			}
+			return isIdempotentUpdateOpTermType(typ), nil
+
+		} else {
+			l.rewind()
+			t = l.next()
+			if idempotent, typ, err = parseTerm(l, t); idempotent { // identifier = term | identifier = term + identifier
+				l.mark()
+				if t = l.next(); tkAdd == t {
+					if tkIdentifier != l.next() {
+						return false, errors.New("expected identifier after '+' operator in update operation")
+					}
+					return isIdempotentUpdateOpTermType(typ), nil
+				} else {
+					l.rewind()
+				}
+			} else {
+				return idempotent, err
+			}
+		}
+	case tkAddEqual, tkSubEqual: // identifier += term | identifier -= term
+		t = l.next()
+		if idempotent, typ, err = parseTerm(l, t); !idempotent {
+			return idempotent, err
+		}
+		return isIdempotentUpdateOpTermType(typ), nil
+	case tkLsquare: // identifier '[' term ']' = term
+		if idempotent, _, err = parseTerm(l, t); !idempotent {
+			return idempotent, err
+		}
+		if tkRsquare != l.next() {
+			return false, errors.New("expected closing ']' in update operation")
+		}
+		if tkEqual != l.next() {
+			return false, errors.New("expected '=' in update operation")
+		}
+		if idempotent, _, err = parseTerm(l, t); !idempotent {
+			return idempotent, err
+		}
+	case tkDot: // identifier '.' identifier '=' term
+		if t = l.next(); tkIdentifier != t {
+			return false, errors.New("expected identifier after '+' operator in update operation")
+		}
+		if idempotent, _, err = parseTerm(l, t); !idempotent {
+			return idempotent, err
+		}
+	default:
+		return false, errors.New("unexpected token in update operation")
+	}
+
+	return true, nil
+}
+
+func isIdempotentUpdateOpTermType(typ termType) bool {
+	// Update terms can be one of the following:
+	// * Literal (idempotent, if not a list)
+	// * Bind marker (ambiguous, so not idempotent)
+	// * Function call (ambiguous, so not idempotent)
+	// * Type cast (probably not idempotent)
+	return typ == termSetMapUdtLiteral || typ == termTupleLiteral
+}
+
+func isIdempotentDeleteElementTermType(typ termType) bool {
+	// Delete element terms can be one of the following:
+	// * Literal (idempotent, if not an integer literal)
+	// * Bind marker (ambiguous, so not idempotent)
+	// * Function call (ambiguous, so not idempotent)
+	// * Type cast (ambiguous)
+	return typ != termIntegerLiteral && typ != termBindMarker && typ != termFunctionCall && typ != termCast
+}

--- a/parser/parse_updateop.go
+++ b/parser/parse_updateop.go
@@ -103,11 +103,11 @@ func parseUpdateOp(l *lexer, t token) (idempotent bool, err error) {
 	return true, nil
 }
 
+// Update terms can be one of the following:
+// * Literal (idempotent, if not a list)
+// * Bind marker (ambiguous, so not idempotent)
+// * Function call (ambiguous, so not idempotent)
+// * Type cast (probably not idempotent)
 func isIdempotentUpdateOpTermType(typ termType) bool {
-	// Update terms can be one of the following:
-	// * Literal (idempotent, if not a list)
-	// * Bind marker (ambiguous, so not idempotent)
-	// * Function call (ambiguous, so not idempotent)
-	// * Type cast (probably not idempotent)
 	return typ == termSetMapUdtLiteral || typ == termTupleLiteral
 }

--- a/parser/parse_updateop.go
+++ b/parser/parse_updateop.go
@@ -77,7 +77,7 @@ func parseUpdateOp(l *lexer, t token) (idempotent bool, err error) {
 		}
 		return isIdempotentUpdateOpTermType(typ), nil
 	case tkLsquare: // identifier '[' term ']' = term
-		if idempotent, _, err = parseTerm(l, t); !idempotent {
+		if idempotent, _, err = parseTerm(l, l.next()); !idempotent {
 			return idempotent, err
 		}
 		if tkRsquare != l.next() {
@@ -86,14 +86,17 @@ func parseUpdateOp(l *lexer, t token) (idempotent bool, err error) {
 		if tkEqual != l.next() {
 			return false, errors.New("expected '=' in update operation")
 		}
-		if idempotent, _, err = parseTerm(l, t); !idempotent {
+		if idempotent, _, err = parseTerm(l, l.next()); !idempotent {
 			return idempotent, err
 		}
 	case tkDot: // identifier '.' identifier '=' term
-		if t = l.next(); tkIdentifier != t {
-			return false, errors.New("expected identifier after '+' operator in update operation")
+		if tkIdentifier != l.next() {
+			return false, errors.New("expected identifier after '.' in update operation")
 		}
-		if idempotent, _, err = parseTerm(l, t); !idempotent {
+		if tkEqual != l.next() {
+			return false, errors.New("expected '=' in update operation")
+		}
+		if idempotent, _, err = parseTerm(l, l.next()); !idempotent {
 			return idempotent, err
 		}
 	default:

--- a/parser/parse_updateop_test.go
+++ b/parser/parse_updateop_test.go
@@ -1,0 +1,1 @@
+package parser

--- a/parser/parse_updateop_test.go
+++ b/parser/parse_updateop_test.go
@@ -1,1 +1,117 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseUpdateOp(t *testing.T) {
+	var tests = []struct {
+		updateOp   string
+		idempotent bool
+		hasError   bool
+		msg        string
+	}{
+		{"a = 0", true, false, "simple update operation"},
+		{"a['a'] = 0", true, false, "assign to collection"},
+		{"a[0] = 0", true, false, "assign to collection (integer index)"},
+		{"a.b = 0", true, false, "assign to UDT field"},
+		{"a = [1, 2, 3]", true, false, "assign list"},
+		{"a = {1, 2, 3}", true, false, "assign set"},
+		{"a = {'a': 1, 'b': 2, 'c': 3}", true, false, "assign map"},
+
+		{"a = a + {1, 2}", true, false, "insert into set"},
+		{"a += {1, 2}", true, false, "insert (assign) into set"},
+		{"a = a - {1, 2}", true, false, "remove from set"},
+		{"a -= {1, 2}", true, false, "remove (assign) from set"},
+
+		{"a = a + {'a': 1, 'b': 2}", true, false, "insert into map"},
+		{"a += {'a': 1, 'b': 2}", true, false, "insert (assign) into map"},
+		{"a = a - {'a': 1, 'b': 2}", true, false, "remove from map"},
+		{"a -= {'a': 1, 'b': 2}", true, false, "remove (assign) from map"},
+
+		{"a = a + (1, 'a')", true, false, "insert into tuple"},
+		{"a += (1, 'a')", true, false, "insert (assign) into tuple"},
+		{"a = a - (1, 'a')", true, false, "remove from tuple"},
+		{"a -= (1, 'a')", true, false, "remove (assign) from tuple"},
+
+		// Invalid
+		{"0 = a", false, true, "start w/ term"},
+		{"a[0 = a", false, true, "no closing square bracket"},
+		{"a0] = a", false, true, "no opening square bracket"},
+		{"a. = a", false, true, "no identifier after '.' for UDT field"},
+
+		{"a = a +", false, true, "add with no term"},
+		{"a = a -", false, true, "subtract with no term"},
+		{"a = 1 +", false, true, "add with no identifier"},
+		{"a +=", false, true, "add assign with no term"},
+		{"a -=", false, true, "subtract assign with no term"},
+
+		// Not idempotent
+		{"a = now()", false, false, "simple update operation w/ now()"},
+		{"a[0] = now()", false, false, "assign to collection (integer index) w/ now()"},
+		{"a[now()] = 0", false, false, "assign to collection w/ now() index"},
+		{"a.b = now()", false, false, "assign to UDT field with now()"},
+
+		{"a = a + 1", false, false, "add to counter"},
+		{"a += 1", false, false, "add assign to counter"},
+		{"a = 1 + a", false, false, "add to counter swap term"},
+		{"a = a - 1", false, false, "subtract from counter"},
+		{"a -= 1", false, false, "subtract assign from counter"},
+
+		{"a = a + [1, 2]", false, false, "append to list"},
+		{"a += [1, 2]", false, false, "append assign to list"},
+		{"a = [1, 2] + a", false, false, "prepend to list"},
+
+		{"a = a - [1, 2]", false, false, "remove from list"},
+		{"a -= [1, 2]", false, false, "remove assign to list"},
+
+		{"a = a + (int)1", false, false, "add/append w/ cast"},
+		{"a += (int)1", false, false, "add/append assign w/ cast"},
+		{"a = (int)1 + a", false, false, "add/append (swap term) w/ cast"},
+		{"a = a - (int)1", false, false, "subtract/remove w/ cast"},
+		{"a -= (int)1", false, false, "subtract/remove assign w/ cast"},
+
+		// Ambiguous
+		{"a = a + ?", false, false, "add/append w/ bind marker"},
+		{"a += ?", false, false, "add/append assign w/ bind marker"},
+		{"a = ? + a", false, false, "add/append (swap term) w/ bind marker"},
+		{"a = a - ?", false, false, "subtract/remove w/ bind marker"},
+		{"a -= ?", false, false, "subtract/remove assign w/ bind marker"},
+
+		{"a = a + :name", false, false, "add/append w/ named bind marker"},
+		{"a += :name", false, false, "add/append assign w/ named bind marker"},
+		{"a = :name + a", false, false, "add/append (swap term) w/ named bind marker"},
+		{"a = a - :name", false, false, "subtract/remove w/ named bind marker"},
+		{"a -= :name", false, false, "subtract/remove assign w/ named bind marker"},
+
+		{"a = a + func()", false, false, "add/append w/ function"},
+		{"a += func()", false, false, "add/append assign w/ function"},
+		{"a = func() + a", false, false, "add/append (swap term) w/ function"},
+		{"a = a - func()", false, false, "subtract/remove w/ function"},
+		{"a -= func()", false, false, "subtract/remove assign w/ function"},
+	}
+
+	for _, tt := range tests {
+		var l lexer
+		l.init(tt.updateOp)
+		idempotent, err := parseUpdateOp(&l, l.next())
+		assert.Equal(t, tt.idempotent, idempotent, tt.msg)
+		assert.True(t, (err != nil) == tt.hasError, tt.msg)
+	}
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -15,7 +15,6 @@
 package parser
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,7 +27,7 @@ func TestParser(t *testing.T) {
 		handled    bool
 		idempotent bool
 		stmt       Statement
-		err        error
+		hasError   bool
 	}{
 		{"", "SELECT key, rpc_address AS address, count(*) FROM system.local", true, true, &SelectStatement{
 			Table: "local",
@@ -37,129 +36,129 @@ func TestParser(t *testing.T) {
 				&AliasSelector{Alias: "address", Selector: &IDSelector{Name: "rpc_address"}},
 				&CountStarSelector{Name: "count(*)"},
 			},
-		}, nil},
+		}, false},
 		{"system", "SELECT count(*) FROM local", true, true, &SelectStatement{
 			Table: "local",
 			Selectors: []Selector{
 				&CountStarSelector{Name: "count(*)"},
 			},
-		}, nil},
+		}, false},
 		{"system", "SELECT count(*) FROM \"local\"", true, true, &SelectStatement{
 			Table: "local",
 			Selectors: []Selector{
 				&CountStarSelector{Name: "count(*)"},
 			},
-		}, nil},
+		}, false},
 		{"", "SELECT count(*) FROM system.peers", true, true, &SelectStatement{
 			Table: "peers",
 			Selectors: []Selector{
 				&CountStarSelector{Name: "count(*)"},
 			},
-		}, nil},
+		}, false},
 		{"", "SELECT count(*) FROM \"system\".\"peers\"", true, true, &SelectStatement{
 			Table: "peers",
 			Selectors: []Selector{
 				&CountStarSelector{Name: "count(*)"},
 			},
-		}, nil},
+		}, false},
 		{"system", "SELECT count(*) FROM peers", true, true, &SelectStatement{
 			Table: "peers",
 			Selectors: []Selector{
 				&CountStarSelector{Name: "count(*)"},
 			},
-		}, nil},
+		}, false},
 		{"", "SELECT count(*) FROM system.peers_v2", true, true, &SelectStatement{
 			Table: "peers_v2",
 			Selectors: []Selector{
 				&CountStarSelector{Name: "count(*)"},
 			},
-		}, nil},
+		}, false},
 		{"system", "SELECT count(*) FROM peers_v2", true, true, &SelectStatement{
 			Table: "peers_v2",
 			Selectors: []Selector{
 				&CountStarSelector{Name: "count(*)"},
 			},
-		}, nil},
-		{"", "SELECT func(key) FROM system.local", true, true, nil,
-			errors.New("unsupported select clause for system table")},
-		{"", "SELECT JSON * FROM system.local", true, true, nil,
-			errors.New("proxy is unable to do 'JSON' or 'DISTINCT' for handled system queries")},
-		{"", "SELECT DISTINCT * FROM system.local", true, true, nil,
-			errors.New("proxy is unable to do 'JSON' or 'DISTINCT' for handled system queries")},
+		}, false},
+		{"", "SELECT func(key) FROM system.local", true, true, nil, true},
+		{"", "SELECT JSON * FROM system.local", true, true, nil, true},
+		{"", "SELECT DISTINCT * FROM system.local", true, true, nil, true},
 		{"", "USE system", true, false, &UseStatement{
 			Keyspace: "system",
-		}, nil},
+		}, false},
 		// Reads from tables named similarly to system tables (not handled)
-		{"", "SELECT count(*) FROM local", false, true, nil, nil},
-		{"", "SELECT count(*) FROM peers", false, true, nil, nil},
-		{"", "SELECT count(*) FROM peers_v2", false, true, nil, nil},
+		{"", "SELECT count(*) FROM local", false, true, nil, false},
+		{"", "SELECT count(*) FROM peers", false, true, nil, false},
+		{"", "SELECT count(*) FROM peers_v2", false, true, nil, false},
+
+		// Semicolon at the end
+		{"", "SELECT count(*) FROM table;", false, true, nil, false},
 
 		// Mutations to system tables (not handled)
-		{"", "INSERT INTO system.local (key, rpc_address) VALUES ('local1', '127.0.0.1')", false, true, nil, nil},
-		{"", "UPDATE system.local SET rpc_address = '127.0.0.1' WHERE key = 'local'", false, true, nil, nil},
-		{"", "DELETE rpc_address FROM system.local WHERE key = 'local'", false, true, nil, nil},
+		{"", "INSERT INTO system.local (key, rpc_address) VALUES ('local1', '127.0.0.1')", false, true, nil, false},
+		{"", "UPDATE system.local SET rpc_address = '127.0.0.1' WHERE key = 'local'", false, true, nil, false},
+		{"", "DELETE rpc_address FROM system.local WHERE key = 'local'", false, true, nil, false},
 
 		// Mutations that use the functions whose values change e.g. uuid(), now() (not idempotent)
-		{"", "INSERT INTO ks.table (key, value) VALUES ('k1', uuid())", false, false, nil, nil},
-		{"", "INSERT INTO ks.table (key, value) VALUES ('k1', now())", false, false, nil, nil},
-		{"", "INSERT INTO ks.table (key, value) VALUES ('k1', nested(now()))", false, false, nil, nil},
-		{"", "INSERT INTO ks.table (key, value) VALUES ('k1', nested(uuid()))", false, false, nil, nil},
-		{"", "UPDATE ks.table SET v = uuid() WHERE k = 1", false, false, nil, nil},
-		{"", "UPDATE ks.table SET v = now() WHERE k = 1", false, false, nil, nil},
-		{"", "UPDATE ks.table SET v = nested(uuid()) WHERE k = 1", false, false, nil, nil},
-		{"", "UPDATE ks.table SET v = nested(now()) WHERE k = 1", false, false, nil, nil},
+		{"", "INSERT INTO ks.table (key, value) VALUES ('k1', uuid())", false, false, nil, false},
+		{"", "INSERT INTO ks.table (key, value) VALUES ('k1', now())", false, false, nil, false},
+		{"", "INSERT INTO ks.table (key, value) VALUES ('k1', nested(now()))", false, false, nil, false},
+		{"", "INSERT INTO ks.table (key, value) VALUES ('k1', nested(uuid()))", false, false, nil, false},
+		{"", "UPDATE ks.table SET v = uuid() WHERE k = 1", false, false, nil, false},
+		{"", "UPDATE ks.table SET v = now() WHERE k = 1", false, false, nil, false},
+		{"", "UPDATE ks.table SET v = nested(uuid()) WHERE k = 1", false, false, nil, false},
+		{"", "UPDATE ks.table SET v = nested(now()) WHERE k = 1", false, false, nil, false},
 
 		// Updates that prepend/append to a list (not idempotent)
-		{"", "UPDATE ks.table SET v = v + [1] WHERE k = 1", false, false, nil, nil}, // Append
-		{"", "UPDATE ks.table SET v = [1] + v WHERE k = 1", false, false, nil, nil}, // Prepend
-		{"", "UPDATE ks.table SET v += [1] WHERE k = 1", false, false, nil, nil},    // Append assign
-		{"", "UPDATE ks.table SET v -= [1] WHERE k = 1", false, false, nil, nil},    // Remove assign
+		{"", "UPDATE ks.table SET v = v + [1] WHERE k = 1", false, false, nil, false}, // Append
+		{"", "UPDATE ks.table SET v = [1] + v WHERE k = 1", false, false, nil, false}, // Prepend
+		{"", "UPDATE ks.table SET v += [1] WHERE k = 1", false, false, nil, false},    // Append assign
+		{"", "UPDATE ks.table SET v -= [1] WHERE k = 1", false, false, nil, false},    // Remove assign
 
 		// Updates to counter values (not idempotent)
-		{"", "UPDATE ks.table SET v = v + 1 WHERE k = 1", false, false, nil, nil}, // Left add
-		{"", "UPDATE ks.table SET v = 1 + v WHERE k = 1", false, false, nil, nil}, // Right add
-		{"", "UPDATE ks.table SET v += 1 WHERE k = 1", false, false, nil, nil},    // Add assign
-		{"", "UPDATE ks.table SET v = v - 1 WHERE k = 1", false, false, nil, nil}, // Left subtract
-		{"", "UPDATE ks.table SET v -= 1 WHERE k = 1", false, false, nil, nil},    // Subtract assign
+		{"", "UPDATE ks.table SET v = v + 1 WHERE k = 1", false, false, nil, false}, // Left add
+		{"", "UPDATE ks.table SET v = 1 + v WHERE k = 1", false, false, nil, false}, // Right add
+		{"", "UPDATE ks.table SET v += 1 WHERE k = 1", false, false, nil, false},    // Add assign
+		{"", "UPDATE ks.table SET v = v - 1 WHERE k = 1", false, false, nil, false}, // Left subtract
+		{"", "UPDATE ks.table SET v -= 1 WHERE k = 1", false, false, nil, false},    // Subtract assign
 
 		// Update set/map (idempotent)
-		{"", "UPDATE ks.table SET v = v + { 1 } WHERE k = 1", false, true, nil, nil},        // Add to set (right)
-		{"", "UPDATE ks.table SET v = { 1 } + v WHERE k = 1", false, true, nil, nil},        // Add to set (left)
-		{"", "UPDATE ks.table SET v = v + { 'a': 1 } WHERE k = 1", false, true, nil, nil},   // Add to map (right)
-		{"", "UPDATE ks.table SET v =  { 'a': 1 } +  v WHERE k = 1", false, true, nil, nil}, // Add to map (left)
+		{"", "UPDATE ks.table SET v = v + { 1 } WHERE k = 1", false, true, nil, false},        // Add to set (right)
+		{"", "UPDATE ks.table SET v = { 1 } + v WHERE k = 1", false, true, nil, false},        // Add to set (left)
+		{"", "UPDATE ks.table SET v = v + { 'a': 1 } WHERE k = 1", false, true, nil, false},   // Add to map (right)
+		{"", "UPDATE ks.table SET v =  { 'a': 1 } +  v WHERE k = 1", false, true, nil, false}, // Add to map (left)
 
 		// Deletes to elements of a collection (not idempotent)
-		{"", "DELETE v[0] FROM ks.table WHERE k = 1", false, false, nil, nil},
+		{"", "DELETE v[0] FROM ks.table WHERE k = 1", false, false, nil, false},
 
 		// Deletes to elements of a collection (idempotent)
-		{"", "DELETE v['a'] FROM ks.table WHERE k = 1", false, true, nil, nil},                                  // String
-		{"", "DELETE v[0.0] FROM ks.table WHERE k = 1", false, true, nil, nil},                                  // Float
-		{"", "DELETE v[0x1] FROM ks.table WHERE k = 1", false, true, nil, nil},                                  // Hex (which is different from int)
-		{"", "DELETE v[true] FROM ks.table WHERE k = 1", false, true, nil, nil},                                 // Boolean true
-		{"", "DELETE v[false] FROM ks.table WHERE k = 1", false, true, nil, nil},                                // Boolean false
-		{"", "DELETE v[(1,2,3)] FROM ks.table WHERE k = 1", false, true, nil, nil},                              // Tuple
-		{"", "DELETE v[{field1: 1, field2: 'a'}] FROM ks.table WHERE k = 1", false, true, nil, nil},             // UDT
-		{"", "DELETE v[[1,2,3]] FROM ks.table WHERE k = 1", false, true, nil, nil},                              // List
-		{"", "DELETE v[{1,2,3}] FROM ks.table WHERE k = 1", false, true, nil, nil},                              // Set
-		{"", "DELETE v[{'a': 1}] FROM ks.table WHERE k = 1", false, true, nil, nil},                             // Map
-		{"", "DELETE v[Nan] FROM ks.table WHERE k = 1", false, true, nil, nil},                                  // Nan (float)
-		{"", "DELETE v[Infinity] FROM ks.table WHERE k = 1", false, true, nil, nil},                             // Infinity (float)
-		{"", "DELETE v[null] FROM ks.table WHERE k = 1", false, true, nil, nil},                                 // Null
-		{"", "DELETE v[2021Y12M03D] FROM ks.table WHERE k = 1", false, true, nil, nil},                          // Duration
-		{"", "DELETE v[123e4567-e89b-12d3-a456-426614174000] FROM ks.table WHERE k = 1", false, true, nil, nil}, // UUID
+		{"", "DELETE v['a'] FROM ks.table WHERE k = 1", false, true, nil, false},                                  // String
+		{"", "DELETE v[0.0] FROM ks.table WHERE k = 1", false, true, nil, false},                                  // Float
+		{"", "DELETE v[0x1] FROM ks.table WHERE k = 1", false, true, nil, false},                                  // Hex (which is different from int)
+		{"", "DELETE v[true] FROM ks.table WHERE k = 1", false, true, nil, false},                                 // Boolean true
+		{"", "DELETE v[false] FROM ks.table WHERE k = 1", false, true, nil, false},                                // Boolean false
+		{"", "DELETE v[(1,2,3)] FROM ks.table WHERE k = 1", false, true, nil, false},                              // Tuple
+		{"", "DELETE v[{field1: 1, field2: 'a'}] FROM ks.table WHERE k = 1", false, true, nil, false},             // UDT
+		{"", "DELETE v[[1,2,3]] FROM ks.table WHERE k = 1", false, true, nil, false},                              // List
+		{"", "DELETE v[{1,2,3}] FROM ks.table WHERE k = 1", false, true, nil, false},                              // Set
+		{"", "DELETE v[{'a': 1}] FROM ks.table WHERE k = 1", false, true, nil, false},                             // Map
+		{"", "DELETE v[Nan] FROM ks.table WHERE k = 1", false, true, nil, false},                                  // Nan (float)
+		{"", "DELETE v[Infinity] FROM ks.table WHERE k = 1", false, true, nil, false},                             // Infinity (float)
+		{"", "DELETE v[null] FROM ks.table WHERE k = 1", false, true, nil, false},                                 // Null
+		{"", "DELETE v[2021Y12M03D] FROM ks.table WHERE k = 1", false, true, nil, false},                          // Duration
+		{"", "DELETE v[123e4567-e89b-12d3-a456-426614174000] FROM ks.table WHERE k = 1", false, true, nil, false}, // UUID
 
 		// Lightweight transactions (LWTs are not idempotent)
-		{"", "INSERT INTO ks.table (k, v) VALUES ('a', 1) IF NOT EXISTS", false, false, nil, nil},
-		{"", "UPDATE ks.table SET v = 1 WHERE k = 'a' IF v > 2", false, false, nil, nil},
-		{"", "UPDATE ks.table SET v = 1 WHERE k = 'a' IF EXISTS", false, false, nil, nil},
-		{"", "UPDATE ks.table SET v = 1 WHERE k = 'a' IF NOT EXISTS", false, false, nil, nil},
-		{"", "DELETE FROM ks.table WHERE k = 'a' IF EXISTS", false, false, nil, nil},
-		{"", "DELETE a.b, c.d FROM ks.table WHERE k = 'a' IF EXISTS", false, false, nil, nil},
+		{"", "INSERT INTO ks.table (k, v) VALUES ('a', 1) IF NOT EXISTS", false, false, nil, false},
+		{"", "UPDATE ks.table SET v = 1 WHERE k = 'a' IF v > 2", false, false, nil, false},
+		{"", "UPDATE ks.table SET v = 1 WHERE k = 'a' IF EXISTS", false, false, nil, false},
+		{"", "UPDATE ks.table SET v = 1 WHERE k = 'a' IF NOT EXISTS", false, false, nil, false},
+		{"", "DELETE FROM ks.table WHERE k = 'a' IF EXISTS", false, false, nil, false},
+		{"", "DELETE a.b, c.d FROM ks.table WHERE k = 'a' IF EXISTS", false, false, nil, false},
 	}
 
 	for _, tt := range tests {
 		handled, stmt, err := IsQueryHandled(IdentifierFromString(tt.keyspace), tt.query)
-		assert.Equal(t, tt.err, err, tt.query)
+		assert.True(t, (err != nil) == tt.hasError, tt.query)
 
 		idempotent, err := IsQueryIdempotent(tt.query)
 		assert.Nil(t, err, tt.query)

--- a/parser/parser_utils.go
+++ b/parser/parser_utils.go
@@ -28,6 +28,8 @@ const (
 
 var systemTables = []string{"local", "peers", "peers_v2", "schema_keyspaces", "schema_columnfamilies", "schema_columns", "schema_usertypes"}
 
+var nonIdempotentFuncs = []string{"uuid", "now"}
+
 type ValueLookupFunc func(name string) (value message.Column, err error)
 
 func FilterValues(stmt *SelectStatement, columns []*message.ColumnMetadata, valueFunc ValueLookupFunc) (filtered []message.Column, err error) {
@@ -129,6 +131,15 @@ func columnFromSelector(selector Selector, columns []*message.ColumnMetadata, ta
 func isSystemTable(name Identifier) bool {
 	for _, table := range systemTables {
 		if name.equal(table) {
+			return true
+		}
+	}
+	return false
+}
+
+func isNonIdempotentFunc(name Identifier) bool {
+	for _, funcName := range nonIdempotentFuncs {
+		if name.equal(funcName) {
 			return true
 		}
 	}

--- a/parser/parser_utils.go
+++ b/parser/parser_utils.go
@@ -176,3 +176,16 @@ func parseQualifiedIdentifier(l *lexer) (keyspace, target Identifier, t token, e
 		return Identifier{}, temp, t, nil
 	}
 }
+
+func parseIdentifiers(l *lexer, t token) (err error) {
+	for tkRparen != t && tkEOF != t {
+		if tkIdentifier != t {
+			return errors.New("expected identifier")
+		}
+		t = skipToken(l, l.next(), tkComma)
+	}
+	if tkRparen != t {
+		return errors.New("expected closing ')' for identifiers")
+	}
+	return nil
+}


### PR DESCRIPTION
This adds support for determining if a mutation query (`INSERT`, `UPDATE` and `DELETE`) is idempotent. Here are the basic rules:

https://docs.datastax.com/en/devapp/doc/devapp/driversQueryIdempotence.html

There are some cases that are ambiguous (outlined in the code); this PR errors on the side of not marking those queries as idempotent. These ambiguous cases can be resolved in the future using prepared and/or schema metadata to determine column types. The vast majority of queries can validly checked without this extra data.

A substantial portion of this is generated code (`lexer.go` can be ignored, unless curious): 
![image](https://user-images.githubusercontent.com/3710715/147290248-a2cd670c-d0ec-436b-baa6-2d8f284937b6.png)
