### PR TITLE
Add support for batches

### DIFF
--- a/parser/parse_batch_test.go
+++ b/parser/parse_batch_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsIdempotentBatchStmt(t *testing.T) {
+	var tests = []struct {
+		query      string
+		idempotent bool
+		hasError   bool
+		msg        string
+	}{
+		// Idempotent
+		{`BEGIN BATCH
+					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1)
+				 APPLY BATCH`,
+			true, false, "simple"},
+		{`BEGIN BATCH
+				 APPLY BATCH`,
+			true, false, "empty"},
+		{`BEGIN BATCH
+					UPDATE ks.table SET b = 0 WHERE a > 100
+					DELETE a FROM ks.table
+					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1)
+					INSERT INTO table (a, b, c) VALUES (2, 'b', 0.2)
+				 APPLY BATCH`,
+			true, false, "multiple statements"},
+
+		// Invalid
+		{`BATCH
+					SELECT * FROM table
+				 APPLY BATCH`,
+			false, true, "no starting 'BEGIN'"},
+		{`BEGIN BATCH
+					SELECT * FROM table
+				 APPLY BATCH`,
+			false, true, "contains 'SELECT'"},
+		{`BEGIN
+					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+				 APPLY BATCH`,
+			false, true, "no starting 'BATCH'"},
+		{`BEGIN BATCH
+					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+				 BATCH`,
+			false, true, "no ending 'APPLY'"},
+		{`BEGIN BATCH
+					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+				 APPLY`,
+			false, true, "no ending 'BATCH'"},
+
+		// Not idempotent
+		{`BEGIN COUNTER BATCH
+					INSERT INTO table (a, b) VALUES ('a', 0) 
+				 APPLY BATCH`,
+			false, false, "batch counter insert"},
+		{`BEGIN COUNTER BATCH
+					UPDATE table SET a = a + 1
+				 APPLY BATCH`,
+			false, false, "batch counter update"},
+		{`BEGIN BATCH
+					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+					DELETE a, b, c[1] FROM ks.table
+				 APPLY BATCH`,
+			false, false, "delete from list in batch"},
+		{`BEGIN BATCH
+					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+					INSERT INTO table (a, b, c) VALUES (now(), 'a', 0.1)
+				 APPLY BATCH`,
+			false, false, "contains now()"},
+	}
+
+	for _, tt := range tests {
+		idempotent, err := IsQueryIdempotent(tt.query)
+		assert.True(t, (err != nil) == tt.hasError, tt.msg)
+		assert.Equal(t, tt.idempotent, idempotent, "invalid idempotency", tt.msg)
+	}
+}

--- a/parser/parse_batch_test.go
+++ b/parser/parse_batch_test.go
@@ -29,60 +29,60 @@ func TestIsIdempotentBatchStmt(t *testing.T) {
 	}{
 		// Idempotent
 		{`BEGIN BATCH
-					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1)
-				 APPLY BATCH`,
+			INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1)
+		  APPLY BATCH`,
 			true, false, "simple"},
 		{`BEGIN BATCH
-				 APPLY BATCH`,
+		 APPLY BATCH`,
 			true, false, "empty"},
 		{`BEGIN BATCH
-					UPDATE ks.table SET b = 0 WHERE a > 100
-					DELETE a FROM ks.table
-					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1)
-					INSERT INTO table (a, b, c) VALUES (2, 'b', 0.2)
-				 APPLY BATCH`,
+			UPDATE ks.table SET b = 0 WHERE a > 100
+			DELETE a FROM ks.table
+			INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1)
+			INSERT INTO table (a, b, c) VALUES (2, 'b', 0.2)
+		  APPLY BATCH`,
 			true, false, "multiple statements"},
 
 		// Invalid
 		{`BATCH
-					SELECT * FROM table
-				 APPLY BATCH`,
+			SELECT * FROM table
+		  APPLY BATCH`,
 			false, true, "no starting 'BEGIN'"},
 		{`BEGIN BATCH
-					SELECT * FROM table
-				 APPLY BATCH`,
+			SELECT * FROM table
+		  APPLY BATCH`,
 			false, true, "contains 'SELECT'"},
 		{`BEGIN
-					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
-				 APPLY BATCH`,
+			INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+		  APPLY BATCH`,
 			false, true, "no starting 'BATCH'"},
 		{`BEGIN BATCH
-					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
-				 BATCH`,
+			INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+		  BATCH`,
 			false, true, "no ending 'APPLY'"},
 		{`BEGIN BATCH
-					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
-				 APPLY`,
+			INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+		  APPLY`,
 			false, true, "no ending 'BATCH'"},
 
 		// Not idempotent
 		{`BEGIN COUNTER BATCH
-					INSERT INTO table (a, b) VALUES ('a', 0) 
-				 APPLY BATCH`,
+			INSERT INTO table (a, b) VALUES ('a', 0) 
+		  APPLY BATCH`,
 			false, false, "batch counter insert"},
 		{`BEGIN COUNTER BATCH
-					UPDATE table SET a = a + 1
-				 APPLY BATCH`,
+			UPDATE table SET a = a + 1
+		  APPLY BATCH`,
 			false, false, "batch counter update"},
 		{`BEGIN BATCH
-					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
-					DELETE a, b, c[1] FROM ks.table
-				 APPLY BATCH`,
+			INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+			DELETE a, b, c[1] FROM ks.table
+		  APPLY BATCH`,
 			false, false, "delete from list in batch"},
 		{`BEGIN BATCH
-					INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
-					INSERT INTO table (a, b, c) VALUES (now(), 'a', 0.1)
-				 APPLY BATCH`,
+			INSERT INTO table (a, b, c) VALUES (1, 'a', 0.1) 
+			INSERT INTO table (a, b, c) VALUES (now(), 'a', 0.1)
+		  APPLY BATCH`,
 			false, false, "contains now()"},
 	}
 

--- a/parser/parse_delete_test.go
+++ b/parser/parse_delete_test.go
@@ -27,7 +27,7 @@ func TestIsIdempotentDeleteStmt(t *testing.T) {
 		hasError   bool
 		msg        string
 	}{
-		{"DELETE FROM table", true, false, "simple table"},
+		{"DELETE FROM table", true, false, "simple"},
 		{"DELETE a FROM table", true, false, "w/ operation"},
 		{"DELETE a FROM ks.table", true, false, "simple qualified table"},
 		{"DELETE a.b FROM table", true, false, "UDT field"},
@@ -37,7 +37,7 @@ func TestIsIdempotentDeleteStmt(t *testing.T) {
 
 		// Invalid
 		{"DELETE a. FROM table", false, true, "no UDT field"},
-		{"DELETE FROM ks.", true, false, "no table after '.'"},
+		{"DELETE FROM ks.", false, true, "no table after '.'"},
 		{"DELETE FROM table WHERE", true, false, "where clause w/ no relation"},
 		{"DELETE a[0 table WHERE b > 0", false, true, "collection element with no closing square bracket"},
 
@@ -45,6 +45,7 @@ func TestIsIdempotentDeleteStmt(t *testing.T) {
 		{"DELETE a, b, c[1] FROM ks.table", false, false, "multiple with list element"},
 		{"DELETE FROM ks.table WHERE a > toTimestamp(now())", false, false, "now() relation"},
 		{"DELETE FROM table WHERE a > 0 IF EXISTS", false, false, "LWT"},
+		{"DELETE a['key'] FROM table WHERE a > 0 IF EXISTS", false, false, "LWT w/ map field"},
 
 		// Ambiguous
 		{"DELETE a[0] FROM ks.table", false, false, "potentially a list element"},

--- a/parser/parse_relation.go
+++ b/parser/parse_relation.go
@@ -21,7 +21,7 @@ import "errors"
 // whereClause: 'WHERE' relation ( 'AND' relation )*
 //
 func parseWhereClause(l *lexer) (idempotent bool, t token, err error) {
-	for t = l.next(); tkIf != t && tkEOF != t; t = skipToken(l, l.next(), tkAnd) {
+	for t = l.next(); tkIf != t && !isDMLTerminator(t); t = skipToken(l, l.next(), tkAnd) {
 		idempotent, err = parseRelation(l, t)
 		if !idempotent {
 			return idempotent, tkInvalid, err

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -17,6 +17,8 @@
 
 package parser
 
+import "errors"
+
 type Selector interface {
 	isSelector()
 }
@@ -91,13 +93,15 @@ func isIdempotentStmt(l *lexer, t token) (idempotent bool, err error) {
 	case tkUse:
 		return false, nil
 	case tkInsert:
-		return isIdempotentInsertStmt(l)
+		idempotent, t, err = isIdempotentInsertStmt(l)
 	case tkUpdate:
-		return isIdempotentUpdateStmt(l)
+		idempotent, t, err = isIdempotentUpdateStmt(l)
 	case tkDelete:
-		return isIdempotentDeleteStmt(l)
+		idempotent, t, err = isIdempotentDeleteStmt(l)
 	case tkBegin:
 		return isIdempotentBatchStmt(l)
+	default:
+		return false, errors.New("invalid statement type")
 	}
-	return false, nil
+	return idempotent && t == tkEOF, err
 }

--- a/parser/parser_utils.go
+++ b/parser/parser_utils.go
@@ -189,3 +189,7 @@ func parseIdentifiers(l *lexer, t token) (err error) {
 	}
 	return nil
 }
+
+func isDMLTerminator(t token) bool {
+	return t == tkEOF || t == tkInsert || t == tkUpdate || t == tkDelete || t == tkApply
+}

--- a/proxy/codecs.go
+++ b/proxy/codecs.go
@@ -127,8 +127,9 @@ func (p partialBatch) GetOpCode() primitive.OpCode {
 }
 
 func (p partialBatch) Clone() message.Message {
-	// TODO
-	return nil
+	queryOrIds := make([]interface{}, len(p.queryOrIds))
+	copy(queryOrIds, p.queryOrIds)
+	return &partialBatch{queryOrIds}
 }
 
 type partialBatchCodec struct{}
@@ -158,7 +159,7 @@ func (p partialBatchCodec) Decode(source io.Reader, version primitive.ProtocolVe
 	for i := 0; i < int(count); i++ {
 		var queryTyp uint8
 		if queryTyp, err = primitive.ReadByte(source); err != nil {
-			return nil, fmt.Errorf("cannot read BATCH child type for child #%d: %w", i, err)
+			return nil, fmt.Errorf("cannot read BATCH query type for child #%d: %w", i, err)
 		}
 		var queryOrId interface{}
 		switch primitive.BatchChildType(queryTyp) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -333,6 +333,7 @@ func (c *client) Receive(reader io.Reader) error {
 	case *partialQuery:
 		c.handleQuery(raw, msg)
 	case *partialBatch:
+		c.execute(raw, notDetermined, c.keyspace, msg)
 	default:
 		c.send(raw.Header, &message.ProtocolError{ErrorMessage: "Unsupported operation"})
 	}

--- a/proxy/proxy_retries_test.go
+++ b/proxy/proxy_retries_test.go
@@ -50,29 +50,29 @@ func TestProxy_Retries(t *testing.T) {
 			"bootstrapping error",
 			idempotentQuery,
 			&message.IsBootstrapping{ErrorMessage: "Bootstrapping"},
-			3,
-			2,
+			3, // Ran the query on all nodes
+			2, // Retried on all remaining nodes
 		},
 		{
 			"bootstrapping w/ non-idempotent query",
 			nonIdempotentQuery,
 			&message.IsBootstrapping{ErrorMessage: "Bootstrapping"},
-			3,
-			2,
+			3, // Ran the query on all nodes
+			2, // Retried on all remaining nodes
 		},
 		{
 			"error response (truncate), retry until succeeds or exhausts query plan",
 			idempotentQuery,
 			&message.TruncateError{ErrorMessage: "Truncate"},
-			3,
-			2,
+			3, // Ran the query on all nodes
+			2, // Retried on all remaining nodes
 		},
 		{
 			"error response (truncate) w/ non-idempotent query, retry until succeeds or exhausts query plan",
 			nonIdempotentQuery,
 			&message.TruncateError{ErrorMessage: "Truncate"},
-			1,
-			0,
+			1, // Tried the queried on the first node and it failed
+			0, // Did not retry
 		},
 		{
 			"error response (read failure), don't retry",
@@ -84,8 +84,8 @@ func TestProxy_Retries(t *testing.T) {
 				BlockFor:     2,
 				NumFailures:  1,
 			},
-			1,
-			0,
+			1, // Tried the query on the first node and it failed
+			0, // Did not retry
 		},
 		{
 			"error response (write failure), don't retry",
@@ -98,8 +98,8 @@ func TestProxy_Retries(t *testing.T) {
 				NumFailures:  1,
 				WriteType:    primitive.WriteTypeSimple,
 			},
-			1,
-			0,
+			1, // Tried the query on the first node and it failed
+			0, // Did not retry
 		},
 		{
 			"unavailable error, retry on the next node",
@@ -110,8 +110,8 @@ func TestProxy_Retries(t *testing.T) {
 				Required:     2,
 				Alive:        1,
 			},
-			2,
-			1,
+			2, // Tried and failed on the first node, then retried on the next node
+			1, // Retried on the next node
 		},
 		{
 			"unavailable error w/ non-idempotent query, retry on the next node (same)",
@@ -122,8 +122,8 @@ func TestProxy_Retries(t *testing.T) {
 				Required:     2,
 				Alive:        1,
 			},
-			2,
-			1,
+			2, // Tried and failed on the first node, then retried on the next node
+			1, // Retried on the next node
 		},
 		{
 			"read timeout error, retry once on the same node",
@@ -135,8 +135,8 @@ func TestProxy_Retries(t *testing.T) {
 				BlockFor:     2,
 				DataPresent:  false, // Data wasn't present, read repair, retry
 			},
-			1,
-			1,
+			1, // Tried and retried on a single node
+			1, // Retried on the same node
 		},
 		{
 			"read timeout error w/ non-idempotent query, retry once on the same node (same)",
@@ -148,8 +148,8 @@ func TestProxy_Retries(t *testing.T) {
 				BlockFor:     2,
 				DataPresent:  false, // Data wasn't present, read repair, retry
 			},
-			1,
-			1,
+			1, // Tried and retried on a single node
+			1, // Retried on the same node
 		},
 		{
 			"read timeout error w/ unmet conditions, don't retry",
@@ -161,12 +161,14 @@ func TestProxy_Retries(t *testing.T) {
 				BlockFor:     2,
 				DataPresent:  true, // Data was present don't retry
 			},
-			1,
-			0,
+			1, // Tried the query on the first node and it failed
+			0, // Did not retry
 		},
 		{
 			"write timeout error, retry once if logged batch",
-			idempotentQuery, // Not a logged batch, but it doesn't matter for this test
+			// Not actually a logged batch query, but this is opaque to the proxy and mock cluster. It's considered a
+			// logged batch because the error returned by the server says it is.
+			idempotentQuery,
 			&message.WriteTimeout{
 				ErrorMessage: "WriteTimeout",
 				Consistency:  primitive.ConsistencyLevelQuorum,
@@ -174,12 +176,12 @@ func TestProxy_Retries(t *testing.T) {
 				BlockFor:     2,
 				WriteType:    primitive.WriteTypeBatchLog, // Retry if a logged batch
 			},
-			1,
-			1,
+			1, // Tried and retried on a single node
+			1, // Retried on the same node
 		},
 		{
-			"write timeout error w/ unmet conditions, don't retry",
-			idempotentQuery,
+			"write timeout error w/ not a logged batch, don't retry",
+			idempotentQuery, // Opaque idempotent query (see reason it's not an actual batch query above)
 			&message.WriteTimeout{
 				ErrorMessage: "WriteTimeout",
 				Consistency:  primitive.ConsistencyLevelQuorum,
@@ -187,8 +189,8 @@ func TestProxy_Retries(t *testing.T) {
 				BlockFor:     2,
 				WriteType:    primitive.WriteTypeSimple, // Don't retry for anything other than logged batches
 			},
-			1,
-			0,
+			1, // Tried the query on the first node and it failed
+			0, // Did not retry
 		},
 	}
 

--- a/proxy/retrypolicy.go
+++ b/proxy/retrypolicy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/datastax/go-cassandra-native-protocol/primitive"
 )
 
+// RetryDecision is a type used for deciding what to do when a request has failed.
 type RetryDecision int
 
 func (r RetryDecision) String() string {
@@ -34,15 +35,34 @@ func (r RetryDecision) String() string {
 }
 
 const (
+	// RetrySame should be returned when a request should be retried on the same host.
 	RetrySame RetryDecision = iota
+	// RetryNext should be returned when a request should be retried on the next host according to the request's query
+	// plan.
 	RetryNext
+	// ReturnError should be returned when a request's original error should be forwarded along to the client.
 	ReturnError
 )
 
+// RetryPolicy is an interface for defining retry behavior when a server-side error occurs.
 type RetryPolicy interface {
+	// OnReadTimeout handles the retry decision for a server-side read timeout error (Read_timeout = 0x1200).
+	// This occurs when a replica read request times out during a read query.
 	OnReadTimeout(msg *message.ReadTimeout, retryCount int) RetryDecision
+
+	// OnWriteTimeout handles the retry decision for a server-side write timeout error (Write_timeout = 0x1100).
+	// This occurs when a replica write request times out during a write query.
 	OnWriteTimeout(msg *message.WriteTimeout, retryCount int) RetryDecision
+
+	// OnUnavailable handles the retry decision for a server-side unavailable exception (Unavailable = 0x1000).
+	// This occurs when a coordinator determines that there are not enough replicas to handle a query at the requested
+	// consistency level.
 	OnUnavailable(msg *message.Unavailable, retryCount int) RetryDecision
+
+	// OnErrorResponse handles the retry decision for other potentially recoverable errors.
+	// This can be called for the following error types: server error (ServerError = 0x0000),
+	// overloaded (Overloaded = 0x1001), truncate error (Truncate_error = 0x1003), read failure (Read_failure = 0x1300),
+	// and write failure (Write_failure = 0x1500).
 	OnErrorResponse(msg message.Error, retryCount int) RetryDecision
 }
 
@@ -50,10 +70,18 @@ type defaultRetryPolicy struct{}
 
 var defaultRetryPolicyInstance defaultRetryPolicy
 
+// NewDefaultRetryPolicy creates a new default retry policy.
+// The default retry policy takes a conservative approach to retrying requests. In most cases it retries only once in
+// cases where a retry is likely to succeed.
 func NewDefaultRetryPolicy() RetryPolicy {
 	return &defaultRetryPolicyInstance
 }
 
+// OnReadTimeout retries in the case where there were enough replicas to satisfy the request, but one of the replicas
+// didn't respond with data and timed out. It's likely that a single retry to the same coordinator will succeed because
+// it will have recognized the replica as dead before the retry is attempted.
+//
+// In all other cases it will forward the original error to the client.
 func (d defaultRetryPolicy) OnReadTimeout(msg *message.ReadTimeout, retryCount int) RetryDecision {
 	if retryCount == 0 && msg.Received >= msg.BlockFor && !msg.DataPresent {
 		return RetrySame
@@ -62,6 +90,11 @@ func (d defaultRetryPolicy) OnReadTimeout(msg *message.ReadTimeout, retryCount i
 	}
 }
 
+// OnWriteTimeout retries in the case where a coordinator failed to write its batch log to a set of datacenter local
+// nodes. It's likely that a single retry to the same coordinator will succeed because it will have recognized the
+// dead nodes and use a different set of nodes.
+//
+// In all other cases it will forward the original error to the client.
 func (d defaultRetryPolicy) OnWriteTimeout(msg *message.WriteTimeout, retryCount int) RetryDecision {
 	if retryCount == 0 && msg.WriteType == primitive.WriteTypeBatchLog {
 		return RetrySame
@@ -70,6 +103,8 @@ func (d defaultRetryPolicy) OnWriteTimeout(msg *message.WriteTimeout, retryCount
 	}
 }
 
+// OnUnavailable retries, once, on the next coordinator in the query plan. This is to handle the case where a
+// coordinator is failing because it was partitioned from a set of its replicas.
 func (d defaultRetryPolicy) OnUnavailable(_ *message.Unavailable, retryCount int) RetryDecision {
 	if retryCount == 0 {
 		return RetryNext
@@ -78,6 +113,7 @@ func (d defaultRetryPolicy) OnUnavailable(_ *message.Unavailable, retryCount int
 	}
 }
 
+// OnErrorResponse retries on the next coordinator for all error types except for read and write failures.
 func (d defaultRetryPolicy) OnErrorResponse(msg message.Error, retryCount int) RetryDecision {
 	code := msg.GetErrorCode()
 	if code == primitive.ErrorCodeReadFailure || code == primitive.ErrorCodeWriteFailure {

--- a/proxycore/clientconn.go
+++ b/proxycore/clientconn.go
@@ -212,7 +212,7 @@ func (c *ClientConn) Query(ctx context.Context, version primitive.ProtocolVersio
 	switch msg := response.Body.Message.(type) {
 	case *message.RowsResult:
 		return NewResultSet(msg, version), nil
-	case *message.VoidResult:
+	case *message.VoidResult, *message.PreparedResult:
 		return nil, nil // TODO: Make empty result set
 	case message.Error:
 		return nil, &CqlError{Message: msg}

--- a/proxycore/clientconn.go
+++ b/proxycore/clientconn.go
@@ -203,7 +203,7 @@ func (c *ClientConn) Inflight() int32 {
 	return atomic.LoadInt32(&c.inflight)
 }
 
-func (c *ClientConn) Query(ctx context.Context, version primitive.ProtocolVersion, query *message.Query) (*ResultSet, error) {
+func (c *ClientConn) Query(ctx context.Context, version primitive.ProtocolVersion, query message.Message) (*ResultSet, error) {
 	response, err := c.SendAndReceive(ctx, frame.NewFrame(version, -1, query))
 	if err != nil {
 		return nil, err

--- a/proxycore/errors.go
+++ b/proxycore/errors.go
@@ -17,10 +17,11 @@ package proxycore
 import (
 	"errors"
 	"fmt"
-	"github.com/datastax/go-cassandra-native-protocol/message"
 	"io"
 	"strings"
 	"syscall"
+
+	"github.com/datastax/go-cassandra-native-protocol/message"
 )
 
 var (
@@ -39,7 +40,7 @@ func (e *UnexpectedResponse) Error() string {
 }
 
 type CqlError struct {
-	message.Message
+	Message message.Error
 }
 
 func (e CqlError) Error() string {


### PR DESCRIPTION
Adds support for batches, both the batch CQL native protocol request and the `BEGIN BATCH ... APPLY BATCH` CQL query string.

This also includes some fixes for retries and adds tests for retries of prepared statements.

Fixes: https://github.com/datastax/cql-proxy/issues/55

