### PR TITLE
Add health checks for liveness and readiness

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -16,152 +16,27 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net"
-	"net/http"
 	"os"
 	"os/signal"
-	"strings"
-	"sync"
-	"time"
 
-	"github.com/datastax/cql-proxy/astra"
 	"github.com/datastax/cql-proxy/proxy"
-	"github.com/datastax/cql-proxy/proxycore"
-
-	"github.com/alecthomas/kong"
-	"github.com/datastax/go-cassandra-native-protocol/primitive"
-	"go.uber.org/zap"
 )
 
-const livenessPath = "/liveness"
-const readinessPath = "/readiness"
-
-var cli struct {
-	Bundle             string        `help:"Path to secure connect bundle" short:"b" env:"BUNDLE"`
-	Username           string        `help:"Username to use for authentication" short:"u" env:"USERNAME"`
-	Password           string        `help:"Password to use for authentication" short:"p" env:"PASSWORD"`
-	ContactPoints      []string      `help:"Contact points for cluster. Ignored if using the bundle path option." short:"c" env:"CONTACT_POINTS"`
-	ProtocolVersion    string        `help:"Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" short:"n" env:"PROTOCOL_VERSION"`
-	MaxProtocolVersion string        `help:"Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" short:"m" env:"MAX_PROTOCOL_VERSION"`
-	Bind               string        `help:"Address to use to bind server" short:"a" default:":9042" env:"BIND"`
-	Debug              bool          `help:"Show debug logging" env:"DEBUG"`
-	HealthCheck        bool          `help:"Enable liveness and readiness checks" default:"false" env:"HEALTH_CHECK"`
-	HttpBind           string        `help:"Address to use to bind HTTP server used for health checks" default:":8000" env:"HTTP_BIND"`
-	HeartbeatInterval  time.Duration `help:"Interval between performing heartbeats to the cluster" default:"30s" env:"HEARTBEAT_INTERVAL"`
-	IdleTimeout        time.Duration `help:"Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed" default:"60s" env:"IDLE_TIMEOUT"`
-	ReadinessTimeout   time.Duration `help:"Duration the proxy is unable to connect to the backend cluster before it is considered not ready" default:"30s" env:"READINESS_TIMEOUT"`
-}
-
 func main() {
-	cliCtx := kong.Parse(&cli)
-
-	var resolver proxycore.EndpointResolver
-
-	if len(cli.Bundle) > 0 {
-		bundle, err := astra.LoadBundleZipFromPath(cli.Bundle)
-		if err != nil {
-			cliCtx.Fatalf("unable to open bundle %s: %v", cli.Bundle, err)
-		}
-		resolver = astra.NewResolver(bundle)
-	} else if len(cli.ContactPoints) > 0 {
-		resolver = proxycore.NewResolver(cli.ContactPoints...)
-	} else {
-		cliCtx.Fatalf("must provide either bundle path or contact points")
-	}
-
-	if cli.HeartbeatInterval >= cli.IdleTimeout {
-		cliCtx.Fatalf("idle-timeout must be greater than heartbeat-interval")
-	}
-
-	version := primitive.ProtocolVersion4
-	if len(cli.ProtocolVersion) > 0 {
-		var ok bool
-		if version, ok = parseProtocolVersion(cli.ProtocolVersion); !ok {
-			cliCtx.Fatalf("unsupported protocol version: %s", cli.ProtocolVersion)
-		}
-	}
-
-	maxVersion := primitive.ProtocolVersion4
-	if len(cli.MaxProtocolVersion) > 0 {
-		var ok bool
-		if maxVersion, ok = parseProtocolVersion(cli.MaxProtocolVersion); !ok {
-			cliCtx.Fatalf("unsupported max protocol version: %s", cli.ProtocolVersion)
-		}
-	}
-
-	if version > maxVersion {
-		cliCtx.Fatalf("default protocol version is greater than max protocol version")
-	}
-
 	ctx, cancel := signalContext(context.Background(), os.Interrupt, os.Kill)
 	defer cancel()
 
-	var logger *zap.Logger
-	var err error
-	if cli.Debug {
-		logger, err = zap.NewDevelopment()
-	} else {
-		logger, err = zap.NewProduction()
-	}
-	if err != nil {
-		cliCtx.Fatalf("unable to create logger")
-	}
-
-	var auth proxycore.Authenticator
-
-	if len(cli.Username) > 0 || len(cli.Password) > 0 {
-		auth = proxycore.NewPasswordAuth(cli.Username, cli.Password)
-	}
-
-	p := proxy.NewProxy(ctx, proxy.Config{
-		Version:           version,
-		MaxVersion:        maxVersion,
-		Resolver:          resolver,
-		ReconnectPolicy:   proxycore.NewReconnectPolicy(),
-		NumConns:          1,
-		Auth:              auth,
-		Logger:            logger,
-		HeartBeatInterval: cli.HeartbeatInterval,
-		IdleTimeout:       cli.IdleTimeout,
-	})
-
-	cli.Bind = maybeAddPort(cli.Bind, "9042")
-	cli.HttpBind = maybeAddPort(cli.HttpBind, "8000")
-
-	maybeAddHealthCheck(p)
-
-	cliCtx.FatalIfErrorf(listenAndServe(p, ctx, logger))
-}
-
-func parseProtocolVersion(s string) (version primitive.ProtocolVersion, ok bool) {
-	ok = true
-	lowered := strings.ToLower(s)
-	if lowered == "3" || lowered == "v3" {
-		version = primitive.ProtocolVersion3
-	} else if lowered == "4" || lowered == "v4" {
-		version = primitive.ProtocolVersion4
-	} else if lowered == "5" || lowered == "v5" {
-		version = primitive.ProtocolVersion5
-	} else if lowered == "65" || lowered == "dsev1" {
-		version = primitive.ProtocolVersionDse1
-	} else if lowered == "66" || lowered == "dsev2" {
-		version = primitive.ProtocolVersionDse1
-	} else {
-		ok = false
-	}
-	return version, ok
+	os.Exit(proxy.Run(ctx, os.Args[1:]))
 }
 
 func signalContext(parent context.Context, sig ...os.Signal) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(parent)
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, sig...)
+	ch := make(chan os.Signal)
+	signal.Notify(ch, sig...)
 	if ctx.Err() == nil {
 		go func() {
 			select {
-			case <-c:
+			case <-ch:
 				cancel()
 			case <-ctx.Done():
 			}
@@ -169,117 +44,6 @@ func signalContext(parent context.Context, sig ...os.Signal) (context.Context, f
 	}
 	return ctx, func() {
 		cancel()
-		signal.Stop(c)
+		signal.Stop(ch)
 	}
-}
-
-func maybeAddHealthCheck(p *proxy.Proxy) {
-	if cli.HealthCheck {
-		http.HandleFunc(livenessPath, func(writer http.ResponseWriter, request *http.Request) {
-			writer.WriteHeader(http.StatusOK)
-			_, _ = writer.Write([]byte("ok"))
-		})
-		http.HandleFunc(readinessPath, func(writer http.ResponseWriter, request *http.Request) {
-			header := writer.Header()
-			header.Set("Content-Type", "application/json")
-
-			outageDuration := p.OutageDuration()
-			response, err := json.Marshal(struct {
-				OutageDuration string
-			}{outageDuration.String()})
-			if err != nil {
-				http.Error(writer, fmt.Sprintf("failed to marshal json response: %v", err), http.StatusInternalServerError)
-				return
-			}
-
-			if outageDuration < cli.ReadinessTimeout {
-				writer.WriteHeader(http.StatusOK)
-				_, _ = writer.Write(response)
-			} else {
-				writer.WriteHeader(http.StatusServiceUnavailable)
-				_, _ = writer.Write(response)
-			}
-		})
-	}
-}
-
-//maybeAddPort adds the default port to an IP; otherwise, it returns the original address
-func maybeAddPort(addr string, defaultPort string) string {
-	if net.ParseIP(addr) != nil {
-		return net.JoinHostPort(addr, defaultPort)
-	}
-	return addr
-}
-
-func listenAndServe(p *proxy.Proxy, ctx context.Context, logger *zap.Logger) (err error) {
-	var wg sync.WaitGroup
-
-	ch := make(chan error)
-	server := http.Server{Addr: cli.HttpBind}
-
-	numServers := 1 // Without the HTTP server
-
-	// Listen is called first to set up the listening server connection and establish initial client connections to the
-	// backend cluster so that when the readiness check is hit the proxy is actually ready.
-	err = p.Listen(cli.Bind)
-	if err != nil {
-		return err
-	}
-
-	var listener *net.TCPListener
-
-	if cli.HealthCheck {
-		numServers++ // Add the HTTP server
-
-		tcpAddr, err := net.ResolveTCPAddr("tcp", cli.HttpBind)
-		if err != nil {
-			return err
-		}
-		listener, err = net.ListenTCP("tcp", tcpAddr)
-		if err != nil {
-			return err
-		}
-
-		logger.Info("health checks are listening",
-			zap.String("livenessURL", cli.HttpBind+livenessPath),
-			zap.String("readinessURL", cli.HttpBind+readinessPath))
-	}
-
-	wg.Add(numServers)
-
-	go func() {
-		select {
-		case <-ctx.Done():
-			logger.Debug("proxy interrupted/killed")
-			_ = server.Close()
-			_ = p.Shutdown()
-		}
-	}()
-
-	go func() {
-		defer wg.Done()
-		err = p.Serve()
-		if err != nil {
-			ch <- err
-		}
-	}()
-
-	if cli.HealthCheck {
-		go func() {
-			defer wg.Done()
-			err = server.Serve(listener)
-			if err != nil {
-				ch <- err
-			}
-		}()
-
-	}
-
-	for err = range ch {
-		if err != nil {
-			return nil
-		}
-	}
-
-	return err
 }

--- a/proxy.go
+++ b/proxy.go
@@ -16,10 +16,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
-	_ "net/http/pprof"
+	"os"
+	"os/signal"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/datastax/cql-proxy/astra"
@@ -31,6 +35,9 @@ import (
 	"go.uber.org/zap"
 )
 
+const livenessPath = "/liveness"
+const readinessPath = "/readiness"
+
 var cli struct {
 	Bundle             string        `help:"Path to secure connect bundle" short:"b" env:"BUNDLE"`
 	Username           string        `help:"Username to use for authentication" short:"u" env:"USERNAME"`
@@ -38,30 +45,13 @@ var cli struct {
 	ContactPoints      []string      `help:"Contact points for cluster. Ignored if using the bundle path option." short:"c" env:"CONTACT_POINTS"`
 	ProtocolVersion    string        `help:"Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" short:"n" env:"PROTOCOL_VERSION"`
 	MaxProtocolVersion string        `help:"Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" short:"m" env:"MAX_PROTOCOL_VERSION"`
-	Bind               string        `help:"Address to use to bind serve" short:"a" env:"BIND"`
+	Bind               string        `help:"Address to use to bind server" short:"a" default:":9042" env:"BIND"`
 	Debug              bool          `help:"Show debug logging" env:"DEBUG"`
-	Profiling          bool          `help:"Enable profiling" env:"PROFILING"`
+	HealthCheck        bool          `help:"Enable liveness and readiness checks" default:"false" env:"HEALTH_CHECK"`
+	HttpBind           string        `help:"Address to use to bind HTTP server used for health checks" default:":8000" env:"HTTP_BIND"`
 	HeartbeatInterval  time.Duration `help:"Interval between performing heartbeats to the cluster" default:"30s" env:"HEARTBEAT_INTERVAL"`
-	IdleTimeout        time.Duration `help:"Time between successful heartbeats before a connection to the cluster is considered unresponsive and closed" default:"60s" env:"IDLE_TIMEOUT"`
-}
-
-func parseProtocolVersion(s string) (version primitive.ProtocolVersion, ok bool) {
-	ok = true
-	lowered := strings.ToLower(s)
-	if lowered == "3" || lowered == "v3" {
-		version = primitive.ProtocolVersion3
-	} else if lowered == "4" || lowered == "v4" {
-		version = primitive.ProtocolVersion4
-	} else if lowered == "5" || lowered == "v5" {
-		version = primitive.ProtocolVersion5
-	} else if lowered == "65" || lowered == "dsev1" {
-		version = primitive.ProtocolVersionDse1
-	} else if lowered == "66" || lowered == "dsev2" {
-		version = primitive.ProtocolVersionDse1
-	} else {
-		ok = false
-	}
-	return version, ok
+	IdleTimeout        time.Duration `help:"Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed" default:"60s" env:"IDLE_TIMEOUT"`
+	ReadinessTimeout   time.Duration `help:"Duration the proxy is unable to connect to the backend cluster before it is considered not ready" default:"30s" env:"READINESS_TIMEOUT"`
 }
 
 func main() {
@@ -105,7 +95,8 @@ func main() {
 		cliCtx.Fatalf("default protocol version is greater than max protocol version")
 	}
 
-	ctx := context.Background()
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
+	defer cancel()
 
 	var logger *zap.Logger
 	var err error
@@ -136,22 +127,140 @@ func main() {
 		IdleTimeout:       cli.IdleTimeout,
 	})
 
-	bind, _, err := net.SplitHostPort(cli.Bind)
+	cli.Bind = maybeAddPort(cli.Bind, "9042")
+	cli.HttpBind = maybeAddPort(cli.HttpBind, "8000")
+
+	maybeAddHealthCheck(p)
+
+	cliCtx.FatalIfErrorf(listenAndServe(p, ctx, logger))
+}
+
+func parseProtocolVersion(s string) (version primitive.ProtocolVersion, ok bool) {
+	ok = true
+	lowered := strings.ToLower(s)
+	if lowered == "3" || lowered == "v3" {
+		version = primitive.ProtocolVersion3
+	} else if lowered == "4" || lowered == "v4" {
+		version = primitive.ProtocolVersion4
+	} else if lowered == "5" || lowered == "v5" {
+		version = primitive.ProtocolVersion5
+	} else if lowered == "65" || lowered == "dsev1" {
+		version = primitive.ProtocolVersionDse1
+	} else if lowered == "66" || lowered == "dsev2" {
+		version = primitive.ProtocolVersionDse1
+	} else {
+		ok = false
+	}
+	return version, ok
+}
+
+func maybeAddHealthCheck(p *proxy.Proxy) {
+	if cli.HealthCheck {
+		http.HandleFunc(livenessPath, func(writer http.ResponseWriter, request *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte("ok"))
+		})
+		http.HandleFunc(readinessPath, func(writer http.ResponseWriter, request *http.Request) {
+			header := writer.Header()
+			header.Set("Content-Type", "application/json")
+
+			outageDuration := p.OutageDuration()
+			response, err := json.Marshal(struct {
+				OutageDuration string
+			}{outageDuration.String()})
+			if err != nil {
+				http.Error(writer, fmt.Sprintf("failed to marshal json response: %v", err), http.StatusInternalServerError)
+				return
+			}
+
+			if outageDuration < cli.ReadinessTimeout {
+				writer.WriteHeader(http.StatusOK)
+				_, _ = writer.Write(response)
+			} else {
+				writer.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = writer.Write(response)
+			}
+		})
+	}
+}
+
+//maybeAddPort adds the default port to an IP; otherwise, it returns the original address
+func maybeAddPort(addr string, defaultPort string) string {
+	if net.ParseIP(addr) != nil {
+		return net.JoinHostPort(addr, defaultPort)
+	}
+	return addr
+}
+
+func listenAndServe(p *proxy.Proxy, ctx context.Context, logger *zap.Logger) (err error) {
+	var wg sync.WaitGroup
+
+	ch := make(chan error)
+	server := http.Server{Addr: cli.HttpBind}
+
+	numServers := 1 // Without the HTTP server
+
+	// Listen is called first to set up the listening server connection and establish initial client connections to the
+	// backend cluster so that when the readiness check is hit the proxy is actually ready.
+	err = p.Listen(cli.Bind)
 	if err != nil {
-		bind = net.JoinHostPort(cli.Bind, "9042")
+		return err
 	}
 
-	if cli.Profiling {
+	var listener *net.TCPListener
+
+	if cli.HealthCheck {
+		numServers++ // Add the HTTP server
+
+		tcpAddr, err := net.ResolveTCPAddr("tcp", cli.HttpBind)
+		if err != nil {
+			return err
+		}
+		listener, err = net.ListenTCP("tcp", tcpAddr)
+		if err != nil {
+			return err
+		}
+
+		logger.Info("health checks are listening",
+			zap.String("livenessURL", cli.HttpBind+livenessPath),
+			zap.String("readinessURL", cli.HttpBind+readinessPath))
+	}
+
+	wg.Add(numServers)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			logger.Debug("proxy interrupted/killed")
+			_ = server.Close()
+			_ = p.Shutdown()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		err = p.Serve()
+		if err != nil {
+			ch <- err
+		}
+	}()
+
+	if cli.HealthCheck {
 		go func() {
-			err := http.ListenAndServe("localhost:6060", nil) // Profiling
+			defer wg.Done()
+			err = server.Serve(listener)
 			if err != nil {
-				logger.Error("unable to setup profiling", zap.Error(err))
+				ch <- err
 			}
 		}()
+
 	}
 
-	err = p.ListenAndServe(bind)
-	if err != nil {
-		cliCtx.FatalIfErrorf(err)
+	for err = range ch {
+		if err != nil {
+			return nil
+		}
 	}
+
+	return err
 }

--- a/proxy.go
+++ b/proxy.go
@@ -29,6 +29,7 @@ func main() {
 	os.Exit(proxy.Run(ctx, os.Args[1:]))
 }
 
+// signalContext is a simplified version of `signal.NotifyContext()` for  golang 1.15 and earlier
 func signalContext(parent context.Context, sig ...os.Signal) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(parent)
 	ch := make(chan os.Signal)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -203,6 +203,14 @@ func (p *Proxy) Shutdown() error {
 	return p.listener.Close()
 }
 
+func (p *Proxy) Ready() bool {
+	return true
+}
+
+func (p *Proxy) OutageDuration() time.Duration {
+	return p.cluster.OutageDuration()
+}
+
 func (p *Proxy) handle(conn *net.TCPConn) {
 	if err := conn.SetKeepAlive(false); err != nil {
 		p.logger.Warn("failed to disable keepalive on connection", zap.Error(err))

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -1,0 +1,279 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/datastax/cql-proxy/astra"
+	"github.com/datastax/cql-proxy/proxycore"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
+	"go.uber.org/zap"
+)
+
+const livenessPath = "/liveness"
+const readinessPath = "/readiness"
+
+var cli struct {
+	Bundle             string        `help:"Path to secure connect bundle" short:"b" env:"BUNDLE"`
+	Username           string        `help:"Username to use for authentication" short:"u" env:"USERNAME"`
+	Password           string        `help:"Password to use for authentication" short:"p" env:"PASSWORD"`
+	ContactPoints      []string      `help:"Contact points for cluster. Ignored if using the bundle path option." short:"c" env:"CONTACT_POINTS"`
+	Port               int           `help:"Default port to use when connecting to cluster" default:"9042" short:"t" env:"PORT"`
+	ProtocolVersion    string        `help:"Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"n" env:"PROTOCOL_VERSION"`
+	MaxProtocolVersion string        `help:"Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"m" env:"MAX_PROTOCOL_VERSION"`
+	Bind               string        `help:"Address to use to bind server" short:"a" default:":9042" env:"BIND"`
+	Debug              bool          `help:"Show debug logging" default:"false" env:"DEBUG"`
+	HealthCheck        bool          `help:"Enable liveness and readiness checks" default:"false" env:"HEALTH_CHECK"`
+	HttpBind           string        `help:"Address to use to bind HTTP server used for health checks" default:":8000" env:"HTTP_BIND"`
+	HeartbeatInterval  time.Duration `help:"Interval between performing heartbeats to the cluster" default:"30s" env:"HEARTBEAT_INTERVAL"`
+	IdleTimeout        time.Duration `help:"Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed" default:"60s" env:"IDLE_TIMEOUT"`
+	ReadinessTimeout   time.Duration `help:"Duration the proxy is unable to connect to the backend cluster before it is considered not ready" default:"30s" env:"READINESS_TIMEOUT"`
+}
+
+// Run starts the proxy command. 'args' shouldn't include the executable (i.e. os.Args[1:]). It returns the exit code
+// for the proxy.
+func Run(ctx context.Context, args []string) int {
+	var err error
+
+	parser, err := kong.New(&cli)
+	if err != nil {
+		panic(err)
+	}
+
+	var cliCtx *kong.Context
+	if cliCtx, err = parser.Parse(args); err != nil {
+		parser.Errorf("error parsing cli: %v", err)
+		return 1
+	}
+
+	var resolver proxycore.EndpointResolver
+	if len(cli.Bundle) > 0 {
+		if bundle, err := astra.LoadBundleZipFromPath(cli.Bundle); err != nil {
+			cliCtx.Errorf("unable to open bundle %s: %v", cli.Bundle, err)
+			return 1
+		} else {
+			resolver = astra.NewResolver(bundle)
+		}
+	} else if len(cli.ContactPoints) > 0 {
+		resolver = proxycore.NewResolverWithDefaultPort(cli.ContactPoints, cli.Port)
+	} else {
+		cliCtx.Errorf("must provide either bundle path or contact points")
+		return 1
+	}
+
+	if cli.HeartbeatInterval >= cli.IdleTimeout {
+		cliCtx.Errorf("idle-timeout must be greater than heartbeat-interval")
+		return 1
+	}
+
+	var ok bool
+	var version primitive.ProtocolVersion
+	if version, ok = parseProtocolVersion(cli.ProtocolVersion); !ok {
+		cliCtx.Errorf("unsupported protocol version: %s", cli.ProtocolVersion)
+		return 1
+	}
+
+	var maxVersion primitive.ProtocolVersion
+	if maxVersion, ok = parseProtocolVersion(cli.MaxProtocolVersion); !ok {
+		cliCtx.Errorf("unsupported max protocol version: %s", cli.ProtocolVersion)
+		return 1
+	}
+
+	if version > maxVersion {
+		cliCtx.Errorf("default protocol version is greater than max protocol version")
+		return 1
+	}
+
+	var logger *zap.Logger
+	if cli.Debug {
+		logger, err = zap.NewDevelopment()
+	} else {
+		logger, err = zap.NewProduction()
+	}
+	if err != nil {
+		cliCtx.Errorf("unable to create logger")
+		return 1
+	}
+
+	var auth proxycore.Authenticator
+
+	if len(cli.Username) > 0 || len(cli.Password) > 0 {
+		auth = proxycore.NewPasswordAuth(cli.Username, cli.Password)
+	}
+
+	p := NewProxy(ctx, Config{
+		Version:           version,
+		MaxVersion:        maxVersion,
+		Resolver:          resolver,
+		ReconnectPolicy:   proxycore.NewReconnectPolicy(),
+		NumConns:          1,
+		Auth:              auth,
+		Logger:            logger,
+		HeartBeatInterval: cli.HeartbeatInterval,
+		IdleTimeout:       cli.IdleTimeout,
+	})
+
+	cli.Bind = maybeAddPort(cli.Bind, "9042")
+	cli.HttpBind = maybeAddPort(cli.HttpBind, "8000")
+
+	maybeAddHealthCheck(p)
+
+	err = listenAndServe(p, ctx, logger)
+	if err != nil {
+		cliCtx.Errorf("%v", err)
+		return 1
+	}
+
+	return 0
+}
+
+func parseProtocolVersion(s string) (version primitive.ProtocolVersion, ok bool) {
+	ok = true
+	lowered := strings.ToLower(s)
+	if lowered == "3" || lowered == "v3" {
+		version = primitive.ProtocolVersion3
+	} else if lowered == "4" || lowered == "v4" {
+		version = primitive.ProtocolVersion4
+	} else if lowered == "5" || lowered == "v5" {
+		version = primitive.ProtocolVersion5
+	} else if lowered == "65" || lowered == "dsev1" {
+		version = primitive.ProtocolVersionDse1
+	} else if lowered == "66" || lowered == "dsev2" {
+		version = primitive.ProtocolVersionDse1
+	} else {
+		ok = false
+	}
+	return version, ok
+}
+
+func maybeAddHealthCheck(p *Proxy) {
+	if cli.HealthCheck {
+		http.HandleFunc(livenessPath, func(writer http.ResponseWriter, request *http.Request) {
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write([]byte("ok"))
+		})
+		http.HandleFunc(readinessPath, func(writer http.ResponseWriter, request *http.Request) {
+			header := writer.Header()
+			header.Set("Content-Type", "application/json")
+
+			outageDuration := p.OutageDuration()
+			response, err := json.Marshal(struct {
+				OutageDuration string
+			}{outageDuration.String()})
+			if err != nil {
+				http.Error(writer, fmt.Sprintf("failed to marshal json response: %v", err), http.StatusInternalServerError)
+				return
+			}
+
+			if outageDuration < cli.ReadinessTimeout {
+				writer.WriteHeader(http.StatusOK)
+				_, _ = writer.Write(response)
+			} else {
+				writer.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = writer.Write(response)
+			}
+		})
+	}
+}
+
+//maybeAddPort adds the default port to an IP; otherwise, it returns the original address
+func maybeAddPort(addr string, defaultPort string) string {
+	if net.ParseIP(addr) != nil {
+		return net.JoinHostPort(addr, defaultPort)
+	}
+	return addr
+}
+
+func listenAndServe(p *Proxy, ctx context.Context, logger *zap.Logger) (err error) {
+	var wg sync.WaitGroup
+
+	ch := make(chan error)
+	server := http.Server{Addr: cli.HttpBind}
+
+	numServers := 1 // Without the HTTP server
+
+	// Listen is called first to set up the listening server connection and establish initial client connections to the
+	// backend cluster so that when the readiness check is hit the proxy is actually ready.
+	err = p.Listen(cli.Bind)
+	if err != nil {
+		return err
+	}
+
+	var listener *net.TCPListener
+
+	if cli.HealthCheck {
+		numServers++ // Add the HTTP server
+
+		tcpAddr, err := net.ResolveTCPAddr("tcp", cli.HttpBind)
+		if err != nil {
+			return err
+		}
+		listener, err = net.ListenTCP("tcp", tcpAddr)
+		if err != nil {
+			return err
+		}
+
+		logger.Info("health checks are listening",
+			zap.String("livenessURL", cli.HttpBind+livenessPath),
+			zap.String("readinessURL", cli.HttpBind+readinessPath))
+	}
+
+	wg.Add(numServers)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			logger.Debug("proxy interrupted/killed")
+			_ = server.Close()
+			_ = p.Shutdown()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		err = p.Serve()
+		if err != nil {
+			ch <- err
+		}
+	}()
+
+	if cli.HealthCheck {
+		go func() {
+			defer wg.Done()
+			err = server.Serve(listener)
+			if err != nil {
+				ch <- err
+			}
+		}()
+
+	}
+
+	for err = range ch {
+		if err != nil {
+			return nil
+		}
+	}
+
+	return err
+}

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -167,6 +167,7 @@ func parseProtocolVersion(s string) (version primitive.ProtocolVersion, ok bool)
 	return version, ok
 }
 
+// maybeAddHealthCheck checks the cli flag and adds handlers for health checks if required.
 func maybeAddHealthCheck(p *Proxy) {
 	if cli.HealthCheck {
 		http.HandleFunc(livenessPath, func(writer http.ResponseWriter, request *http.Request) {
@@ -197,7 +198,7 @@ func maybeAddHealthCheck(p *Proxy) {
 	}
 }
 
-//maybeAddPort adds the default port to an IP; otherwise, it returns the original address
+// maybeAddPort adds the default port to an IP; otherwise, it returns the original address.
 func maybeAddPort(addr string, defaultPort string) string {
 	if net.ParseIP(addr) != nil {
 		return net.JoinHostPort(addr, defaultPort)
@@ -205,6 +206,7 @@ func maybeAddPort(addr string, defaultPort string) string {
 	return addr
 }
 
+// listenAndServe correctly handles serving both the proxy and an HTTP server simultaneously.
 func listenAndServe(p *Proxy, ctx context.Context, logger *zap.Logger) (err error) {
 	var wg sync.WaitGroup
 

--- a/proxy/run_test.go
+++ b/proxy/run_test.go
@@ -1,0 +1,93 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/datastax/cql-proxy/proxycore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testProxyHTTPBind = "127.0.0.1:8001"
+)
+
+func TestRun_HealthChecks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster := proxycore.NewMockCluster(net.ParseIP(testClusterStartIP), testClusterPort)
+
+	err := cluster.Add(ctx, 1)
+	require.NoError(t, err)
+
+	defer cluster.Shutdown()
+
+	go func() {
+		require.Equal(t, 0, Run(ctx, []string{
+			"--contact-points", testClusterContactPoint,
+			"--port", strconv.Itoa(testClusterPort),
+			"--health-check",
+			"--http-bind", testProxyHTTPBind,
+			"--readiness-timeout", "200ms", // Use short timeout for the test
+		}))
+	}()
+
+	waitUntil(10*time.Second, func() bool {
+		res, err := http.Get(fmt.Sprintf("http://%s%s", testProxyHTTPBind, livenessPath))
+		return err == nil && res.StatusCode == http.StatusOK
+	})
+
+	// Sanity check the readiness of the cluster
+	outage, status := checkReadiness(t)
+	assert.Equal(t, time.Duration(0), outage)
+	assert.Equal(t, http.StatusOK, status)
+
+	// Stop only node in the cluster to simulate an outage
+	cluster.Stop(1)
+
+	// Wait for the readiness check to fail
+	waitUntil(10*time.Second, func() bool {
+		outage, status = checkReadiness(t)
+		return outage > 0 && status == http.StatusServiceUnavailable
+	})
+
+	// Restart the cluster
+	err = cluster.Start(ctx, 1)
+	require.NoError(t, err)
+
+	// Wait for the readiness check to recover
+	waitUntil(10*time.Second, func() bool {
+		outage, status = checkReadiness(t)
+		return outage == 0 && status == http.StatusOK
+	})
+}
+
+func checkReadiness(t *testing.T) (outage time.Duration, status int) {
+	res, err := http.Get(fmt.Sprintf("http://%s%s", testProxyHTTPBind, readinessPath))
+	require.NoError(t, err)
+
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+
+	var ready struct {
+		OutageDuration string
+	}
+
+	err = json.Unmarshal(body, &ready)
+	require.NoError(t, err)
+
+	outage, err = time.ParseDuration(ready.OutageDuration)
+	require.NoError(t, err)
+
+	return outage, res.StatusCode
+}

--- a/proxy/run_test.go
+++ b/proxy/run_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) DataStax, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package proxy
 
 import (
@@ -32,13 +46,14 @@ func TestRun_HealthChecks(t *testing.T) {
 	defer cluster.Shutdown()
 
 	go func() {
-		require.Equal(t, 0, Run(ctx, []string{
+		rc := Run(ctx, []string{
 			"--contact-points", testClusterContactPoint,
 			"--port", strconv.Itoa(testClusterPort),
 			"--health-check",
 			"--http-bind", testProxyHTTPBind,
 			"--readiness-timeout", "200ms", // Use short timeout for the test
-		}))
+		})
+		require.Equal(t, 0, rc)
 	}()
 
 	waitUntil(10*time.Second, func() bool {

--- a/proxycore/connpool.go
+++ b/proxycore/connpool.go
@@ -37,7 +37,6 @@ type connPool struct {
 	logger        *zap.Logger
 	preparedCache PreparedCache
 	cancel        context.CancelFunc
-	remaining     int32
 	conns         []*ClientConn
 	connsMu       *sync.RWMutex
 }
@@ -53,7 +52,6 @@ func connectPool(ctx context.Context, config connPoolConfig) (*connPool, error) 
 		logger:        GetOrCreateNopLogger(config.Logger),
 		preparedCache: config.PreparedCache,
 		cancel:        cancel,
-		remaining:     int32(config.NumConns),
 		conns:         make([]*ClientConn, config.NumConns),
 		connsMu:       &sync.RWMutex{},
 	}
@@ -91,13 +89,12 @@ func connectPoolNoFail(ctx context.Context, config connPoolConfig) *connPool {
 	ctx, cancel := context.WithCancel(ctx)
 
 	pool := &connPool{
-		ctx:       ctx,
-		config:    config,
-		logger:    GetOrCreateNopLogger(config.Logger),
-		cancel:    cancel,
-		remaining: int32(config.NumConns),
-		conns:     make([]*ClientConn, config.NumConns),
-		connsMu:   &sync.RWMutex{},
+		ctx:     ctx,
+		config:  config,
+		logger:  GetOrCreateNopLogger(config.Logger),
+		cancel:  cancel,
+		conns:   make([]*ClientConn, config.NumConns),
+		connsMu: &sync.RWMutex{},
 	}
 
 	for i := 0; i < config.NumConns; i++ {


### PR DESCRIPTION
This PR add HTTP-based health checks at `/liveness` and `/readiness`.

It also adds new CLI flags:
*  `--health-check` which toggles the HTTP health checks (off by default)
*  `--readiness-timeout` controls how long an outage needs to be before considering the proxy not ready

This also moves most of the "command" code into a new file `run.go` so that the CLI is testable. 

Also, we're now correctly handling signals. 