### PR TITLE
CLI and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,6 @@
 
 `cql-proxy` is designed to forward your application's CQL traffic to an appropriate database service. It listens on a local address and securely forwards that traffic.
 
-**Warning**: `cql-proxy` in its current state works well, and you should give it a try. However, it is still under development, so things might break or change. 
-
-Please give it a try and let us know what you think!
 ## When to use `cql-proxy`
 
 The `cql-proxy` sidecar enables unsupported CQL drivers to work with [DataStax Astra][astra]. These drivers include both legacy DataStax [drivers] and community-maintained CQL drivers, such as the [gocql] driver and the [rust-driver].
@@ -64,12 +61,33 @@ Flags:
 To pass configuration to `cql-proxy`, either command-line flags or environment variables can be used. Using the `docker` method as an example, the following samples show how username, password and bundle are defined with each method.
 ### Using flags
 
+The easiest way to connect `cql-proxy` to Astra is to use your Astra Token and Database ID:
+
+```sh
+docker run -p 9042:9042 \
+  --rm datastax/cql-proxy:v0.0.4 \
+  --astra-token <astra-token> --astra-database-id <astra-datbase-id>
+```
+
+The proxy also support using the Astra Secure Connect Bundle, but it requires mounting the bundle to a volume in the container.
+
+
 ```sh
 docker run -v <your-secure-connect-bundle.zip>:/tmp/scb.zip -p 9042:9042 \
   --rm datastax/cql-proxy:v0.0.4 \
   --astra-bundle /tmp/scb.zip --username <astra-client-id> --password <astra-client-secret>
 ```
 ### Using environment variables
+
+Using the Astra Token:
+
+```sh
+docker run -p 9042:9042  \
+  --rm datastax/cql-proxy:v0.0.4 \
+  -e ASTRA_TOKEN=<astra-token> -e ASTRA_DATABASE_ID=<astra-datbase-id>
+```
+
+or mounting the secure connect bundle:
 
 ```sh
 docker run -v <your-secure-connect-bundle.zip>:/tmp/scb.zip -p 9042:9042  \
@@ -96,8 +114,7 @@ There are three methods for using `cql-proxy`:
    - [DataStax Astra][astra] cluster:
 
       ```sh
-      ./cql-proxy --astra-bundle <your-secure-connect-zip> \
-      --username <astra-client-id> --password <astra-client-secret>
+      ./cql-proxy --astra-token <astra-token> --astra-database-id <astra-database-id>
       ```
    - [Apache Cassandra][cassandra] cluster:
 
@@ -111,11 +128,11 @@ There are three methods for using `cql-proxy`:
    - [DataStax Astra][astra] cluster:
 
       ```sh
-      docker run -v <your-secure-connect-bundle.zip>:/tmp/scb.zip -p 9042:9042 \
+      docker run -p 9042:9042 \
         datastax/cql-proxy:v0.0.4 \
-        --astra-bundle /tmp/scb.zip --username <astra-client-id> --password <astra-client-secret>
+        --astra-token <astra-token> --astra-database-id <astra-database-id>
       ```
-      The `<astra-client-id>` and `<astra-client-secret>` can be generated using these [instructions].
+      The `<astra-token>` can be generated using these [instructions].
 
    - [Apache Cassandra][cassandra] cluster:
 

--- a/README.md
+++ b/README.md
@@ -39,32 +39,42 @@ $ ./cql-proxy -h
 Usage: cql-proxy
 
 Flags:
-  -h, --help               Show context-sensitive help.
-  -b, --bundle=STRING      Path to secure connect bundle ($BUNDLE)
-  -u, --username=STRING    Username to use for authentication ($USERNAME)
-  -p, --password=STRING    Password to use for authentication ($PASSWORD)
-  -c, --contact-points=CONTACT-POINTS,...
-                           Contact points for cluster. Ignored if using the bundle path
-                           option ($CONTACT_POINTS).
-  -a, --bind=STRING        Address to use to bind serve ($BIND)
-      --debug              Show debug logging ($DEBUG)
-      --profiling          Enable profiling ($PROFILING)
+  -h, --help                                 Show context-sensitive help.
+  -b, --astra-bundle=STRING                  Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option
+                                             ($ASTRA_BUNDLE).
+  -t, --astra-token=STRING                   Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option
+                                             ($ASTRA_TOKEN).
+  -i, --astra-database-id=STRING             Database ID of the Astra database. Requires '--astra-token' ($ASTRA_DATABASE_ID)
+  -c, --contact-points=CONTACT-POINTS,...    Contact points for cluster. Ignored if using the bundle path or token option ($CONTACT_POINTS).
+  -u, --username=STRING                      Username to use for authentication ($USERNAME)
+  -p, --password=STRING                      Password to use for authentication ($PASSWORD)
+  -r, --port=9042                            Default port to use when connecting to cluster ($PORT)
+  -n, --protocol-version="v4"                Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2) ($PROTOCOL_VERSION)
+  -m, --max-protocol-version="v4"            Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2) ($MAX_PROTOCOL_VERSION)
+  -a, --bind=":9042"                         Address to use to bind server ($BIND)
+      --debug                                Show debug logging ($DEBUG)
+      --health-check                         Enable liveness and readiness checks ($HEALTH_CHECK)
+      --http-bind=":8000"                    Address to use to bind HTTP server used for health checks ($HTTP_BIND)
+      --heartbeat-interval=30s               Interval between performing heartbeats to the cluster ($HEARTBEAT_INTERVAL)
+      --idle-timeout=60s                     Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed ($IDLE_TIMEOUT)
+      --readiness-timeout=30s                Duration the proxy is unable to connect to the backend cluster before it is considered not ready ($READINESS_TIMEOUT)
+      --num-conns=1                          Number of connection to create to each node of the backend cluster ($NUM_CONNS)
 ```
 
-To pass configuration to `cql-proxy`, either command-line flags or environment variables can be used. Using the `docker` method as an example, the follwing samples show how username, password and bundle are defined with each method.
+To pass configuration to `cql-proxy`, either command-line flags or environment variables can be used. Using the `docker` method as an example, the following samples show how username, password and bundle are defined with each method.
 ### Using flags
 
 ```sh
 docker run -v <your-secure-connect-bundle.zip>:/tmp/scb.zip -p 9042:9042 \
   --rm datastax/cql-proxy:v0.0.4 \
-  --bundle /tmp/scb.zip --username <astra-client-id> --password <astra-client-secret>
+  --astra-bundle /tmp/scb.zip --username <astra-client-id> --password <astra-client-secret>
 ```
 ### Using environment variables
 
 ```sh
 docker run -v <your-secure-connect-bundle.zip>:/tmp/scb.zip -p 9042:9042  \
   --rm datastax/cql-proxy:v0.0.4 \
-  -e BUNDLE=/tmp/scb.zip -e USERNAME=<astra-client-id> -e PASSWORD=<astra-client-secret>
+  -e ASTRA_BUNDLE=/tmp/scb.zip -e USERNAME=<astra-client-id> -e PASSWORD=<astra-client-secret>
 ```
 ## Getting started
 
@@ -86,7 +96,7 @@ There are three methods for using `cql-proxy`:
    - [DataStax Astra][astra] cluster:
 
       ```sh
-      ./cql-proxy --bundle <your-secure-connect-zip> \
+      ./cql-proxy --astra-bundle <your-secure-connect-zip> \
       --username <astra-client-id> --password <astra-client-secret>
       ```
    - [Apache Cassandra][cassandra] cluster:
@@ -103,7 +113,7 @@ There are three methods for using `cql-proxy`:
       ```sh
       docker run -v <your-secure-connect-bundle.zip>:/tmp/scb.zip -p 9042:9042 \
         datastax/cql-proxy:v0.0.4 \
-        --bundle /tmp/scb.zip --username <astra-client-id> --password <astra-client-secret>
+        --astra-bundle /tmp/scb.zip --username <astra-client-id> --password <astra-client-secret>
       ```
       The `<astra-client-id>` and `<astra-client-secret>` can be generated using these [instructions].
 
@@ -128,7 +138,7 @@ Using Kubernetes with `cql-proxy` requires a number of steps:
 
       ```
       command: ["./cql-proxy"]
-      args: ["--bundle=/tmp/scb.zip","--username=Client ID","--password=Client Secret"]
+      args: ["--astra-bundle=/tmp/scb.zip","--username=Client ID","--password=Client Secret"]
       ```
 
 - Volume mounts: Modify `/tmp/` as a volume mount as required.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Flags:
       --num-conns=1                          Number of connection to create to each node of the backend cluster ($NUM_CONNS)
 ```
 
-To pass configuration to `cql-proxy`, either command-line flags or environment variables can be used. Using the `docker` method as an example, the following samples show how username, password and bundle are defined with each method.
+To pass configuration to `cql-proxy`, either command-line flags or environment variables can be used. Using the `docker` method as an example, the following samples show how the token and database ID are defined with each method.
 ### Using flags
 
 ```sh
@@ -96,10 +96,18 @@ There are three methods for using `cql-proxy`:
       ```sh
       ./cql-proxy --astra-token <astra-token> --astra-database-id <astra-database-id>
       ```
+
+      The `<astra-token>` can be generated using these [instructions]. The proxy also supports using the [Astra Secure Connect Bundle][bundle] along with a client ID and secret generated using these [instructions]:
+
+      ```
+      ./cql-proxy --bundle <your-secure-connect-zip> \
+      --username <astra-client-id> --password <astra-client-secret>
+      ```
+
    - [Apache Cassandra][cassandra] cluster:
 
       ```sh
-      ./cql-proxy --contact-points <cluster node IPs or DNS names>
+      ./cql-proxy --contact-points <cluster node IPs or DNS names> [--username <username>] [--password <password>]
       ```
 ### Run a `cql-proxy` docker image
 
@@ -125,7 +133,7 @@ There are three methods for using `cql-proxy`:
       ```sh
       docker run -p 9042:9042 \
         datastax/cql-proxy:v0.0.4 \
-        --contact-points <cluster node IPs or DNS names>
+        --contact-points <cluster node IPs or DNS names> [--username <username>] [--password <password>]
       ```
   If you wish to have the docker image removed after you are done with it, add `--rm` before the image name `datastax/cql-proxy:v0.0.4 `.
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker run -p 9042:9042 \
   --astra-token <astra-token> --astra-database-id <astra-datbase-id>
 ```
 
-The proxy also support using the Astra Secure Connect Bundle, but it requires mounting the bundle to a volume in the container.
+The proxy also supports using the Astra Secure Connect Bundle, but requires mounting the bundle to a volume in the container.
 
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -61,38 +61,18 @@ Flags:
 To pass configuration to `cql-proxy`, either command-line flags or environment variables can be used. Using the `docker` method as an example, the following samples show how username, password and bundle are defined with each method.
 ### Using flags
 
-The easiest way to connect `cql-proxy` to Astra is to use your Astra Token and Database ID:
-
 ```sh
 docker run -p 9042:9042 \
   --rm datastax/cql-proxy:v0.0.4 \
   --astra-token <astra-token> --astra-database-id <astra-datbase-id>
 ```
 
-The proxy also supports using the Astra Secure Connect Bundle, but requires mounting the bundle to a volume in the container.
-
-
-```sh
-docker run -v <your-secure-connect-bundle.zip>:/tmp/scb.zip -p 9042:9042 \
-  --rm datastax/cql-proxy:v0.0.4 \
-  --astra-bundle /tmp/scb.zip --username <astra-client-id> --password <astra-client-secret>
-```
 ### Using environment variables
-
-Using the Astra Token:
 
 ```sh
 docker run -p 9042:9042  \
   --rm datastax/cql-proxy:v0.0.4 \
   -e ASTRA_TOKEN=<astra-token> -e ASTRA_DATABASE_ID=<astra-datbase-id>
-```
-
-or mounting the secure connect bundle:
-
-```sh
-docker run -v <your-secure-connect-bundle.zip>:/tmp/scb.zip -p 9042:9042  \
-  --rm datastax/cql-proxy:v0.0.4 \
-  -e ASTRA_BUNDLE=/tmp/scb.zip -e USERNAME=<astra-client-id> -e PASSWORD=<astra-client-secret>
 ```
 ## Getting started
 
@@ -132,8 +112,14 @@ There are three methods for using `cql-proxy`:
         datastax/cql-proxy:v0.0.4 \
         --astra-token <astra-token> --astra-database-id <astra-database-id>
       ```
-      The `<astra-token>` can be generated using these [instructions].
 
+      The `<astra-token>` can be generated using these [instructions]. The proxy also supports using the [Astra Secure Connect Bundle][bundle], but it requires mounting the bundle to a volume in the container:
+
+      ```sh
+      docker run -v <your-secure-connect-bundle.zip>:/tmp/scb.zip -p 9042:9042 \
+      --rm datastax/cql-proxy:v0.0.4 \
+      --astra-bundle /tmp/scb.zip --username <astra-client-id> --password <astra-client-secret>
+      ```
    - [Apache Cassandra][cassandra] cluster:
 
       ```sh
@@ -215,6 +201,6 @@ Using Kubernetes with `cql-proxy` requires a number of steps:
 [cassandra]: https://cassandra.apache.org/
 [dse]: https://www.datastax.com/products/datastax-enterprise
 [instructions]: https://docs.datastax.com/en/astra/docs/manage-application-tokens.html
-
+[bundle]: https://docs.datastax.com/en/astra/docs/obtaining-database-credentials.html#_getting_your_secure_connect_bundle
 
 

--- a/astra/bundle.go
+++ b/astra/bundle.go
@@ -32,8 +32,6 @@ import (
 	"github.com/datastax/astra-client-go/v2/astra"
 )
 
-const URL = "https://api.astra.datastax.com"
-
 type Bundle struct {
 	tlsConfig *tls.Config
 	host      string

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -140,6 +140,7 @@ func (p *Proxy) Listen(address string) error {
 		ReconnectPolicy:   p.config.ReconnectPolicy,
 		HeartBeatInterval: p.config.HeartBeatInterval,
 		IdleTimeout:       p.config.IdleTimeout,
+		Logger:            p.logger,
 	})
 
 	if err != nil {
@@ -167,6 +168,7 @@ func (p *Proxy) Listen(address string) error {
 		HeartBeatInterval: p.config.HeartBeatInterval,
 		IdleTimeout:       p.config.IdleTimeout,
 		PreparedCache:     p.preparedCache,
+		Logger:            p.logger,
 	})
 
 	if err != nil {
@@ -245,6 +247,7 @@ func (p *Proxy) maybeCreateSession(version primitive.ProtocolVersion, keyspace s
 			Keyspace:          keyspace,
 			HeartBeatInterval: p.config.HeartBeatInterval,
 			IdleTimeout:       p.config.IdleTimeout,
+			Logger:            p.logger,
 		})
 		if err != nil {
 			return nil, err

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -38,6 +38,7 @@ var cli struct {
 	AstraBundle        string        `help:"Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option." short:"b" env:"ASTRA_BUNDLE"`
 	AstraToken         string        `help:"Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option." short:"t" env:"ASTRA_TOKEN"`
 	AstraDatabaseID    string        `help:"Database ID of the Astra database. Requires '--astra-token'" short:"i" env:"ASTRA_DATABASE_ID"`
+	AstraAPIURL        string        `help:"URL for the Astra API" default:"https://api.astra.datastax.com" env:"ASTRA_API_URL"`
 	ContactPoints      []string      `help:"Contact points for cluster. Ignored if using the bundle path or token option." short:"c" env:"CONTACT_POINTS"`
 	Username           string        `help:"Username to use for authentication" short:"u" env:"USERNAME"`
 	Password           string        `help:"Password to use for authentication" short:"p" env:"PASSWORD"`
@@ -82,7 +83,7 @@ func Run(ctx context.Context, args []string) int {
 		if len(cli.AstraDatabaseID) == 0 {
 			cliCtx.Fatalf("database ID is required when using a token")
 		}
-		bundle, err := astra.LoadBundleZipFromURL(astra.URL, cli.AstraDatabaseID, cli.AstraToken, 10*time.Second)
+		bundle, err := astra.LoadBundleZipFromURL(cli.AstraAPIURL, cli.AstraDatabaseID, cli.AstraToken, 10*time.Second)
 		if err != nil {
 			cliCtx.Fatalf("unable to load bundle %s from astra: %v", cli.AstraBundle, err)
 		}

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -35,13 +35,13 @@ const livenessPath = "/liveness"
 const readinessPath = "/readiness"
 
 var cli struct {
-	Bundle             string        `help:"Path to secure connect bundle" short:"b" env:"BUNDLE"`
+	AstraBundle        string        `help:"Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option." short:"b" env:"ASTRA_BUNDLE"`
+	AstraToken         string        `help:"Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option." short:"t" env:"ASTRA_TOKEN"`
+	AstraDatabaseID    string        `help:"Database ID of the Astra database. Requires '--astra-token'" short:"i" env:"ASTRA_DATABASE_ID"`
+	ContactPoints      []string      `help:"Contact points for cluster. Ignored if using the bundle path or token option." short:"c" env:"CONTACT_POINTS"`
 	Username           string        `help:"Username to use for authentication" short:"u" env:"USERNAME"`
 	Password           string        `help:"Password to use for authentication" short:"p" env:"PASSWORD"`
-	Token              string        `help:"Token" short:"t" env:"TOKEN"`
-	DatabaseID         string        `help:"Database ID" short:"i" env:"DATABASE_ID"`
-	ContactPoints      []string      `help:"Contact points for cluster. Ignored if using the bundle path option." short:"c" env:"CONTACT_POINTS"`
-	Port               int           `help:"Default port to use when connecting to cluster" default:"9042" short:"t" env:"PORT"`
+	Port               int           `help:"Default port to use when connecting to cluster" default:"9042" short:"r" env:"PORT"`
 	ProtocolVersion    string        `help:"Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"n" env:"PROTOCOL_VERSION"`
 	MaxProtocolVersion string        `help:"Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"m" env:"MAX_PROTOCOL_VERSION"`
 	Bind               string        `help:"Address to use to bind server" short:"a" default:":9042" env:"BIND"`
@@ -51,6 +51,7 @@ var cli struct {
 	HeartbeatInterval  time.Duration `help:"Interval between performing heartbeats to the cluster" default:"30s" env:"HEARTBEAT_INTERVAL"`
 	IdleTimeout        time.Duration `help:"Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed" default:"60s" env:"IDLE_TIMEOUT"`
 	ReadinessTimeout   time.Duration `help:"Duration the proxy is unable to connect to the backend cluster before it is considered not ready" default:"30s" env:"READINESS_TIMEOUT"`
+	NumConns           int           `help:"Number of connection to create to each node of the backend cluster" default:"1" env:"NUM_CONNS"`
 }
 
 // Run starts the proxy command. 'args' shouldn't include the executable (i.e. os.Args[1:]). It returns the exit code
@@ -70,33 +71,39 @@ func Run(ctx context.Context, args []string) int {
 	}
 
 	var resolver proxycore.EndpointResolver
-	if len(cli.Bundle) > 0 {
-		if bundle, err := astra.LoadBundleZipFromPath(cli.Bundle); err != nil {
-			cliCtx.Errorf("unable to open bundle %s from file: %v", cli.Bundle, err)
+	if len(cli.AstraBundle) > 0 {
+		if bundle, err := astra.LoadBundleZipFromPath(cli.AstraBundle); err != nil {
+			cliCtx.Errorf("unable to open bundle %s from file: %v", cli.AstraBundle, err)
 			return 1
 		} else {
 			resolver = astra.NewResolver(bundle)
 		}
-	} else if len(cli.ContactPoints) > 0 {
-		resolver = proxycore.NewResolverWithDefaultPort(cli.ContactPoints, cli.Port)
-	} else if len(cli.Token) > 0 {
-		if len(cli.DatabaseID) == 0 {
+	} else if len(cli.AstraToken) > 0 {
+		if len(cli.AstraDatabaseID) == 0 {
 			cliCtx.Fatalf("database ID is required when using a token")
 		}
-		bundle, err := astra.LoadBundleZipFromURL(astra.URL, cli.DatabaseID, cli.Token, 10*time.Second)
+		bundle, err := astra.LoadBundleZipFromURL(astra.URL, cli.AstraDatabaseID, cli.AstraToken, 10*time.Second)
 		if err != nil {
-			cliCtx.Fatalf("unable to load bundle %s from astra: %v", cli.Bundle, err)
+			cliCtx.Fatalf("unable to load bundle %s from astra: %v", cli.AstraBundle, err)
 		}
 		resolver = astra.NewResolver(bundle)
 		cli.Username = "token"
-		cli.Password = cli.Token
+		cli.Password = cli.AstraToken
+	} else if len(cli.ContactPoints) > 0 {
+		resolver = proxycore.NewResolverWithDefaultPort(cli.ContactPoints, cli.Port)
 	} else {
-		cliCtx.Errorf("must provide either bundle path or contact points")
+		cliCtx.Errorf("must provide either bundle path, token, or contact points")
 		return 1
 	}
 
 	if cli.HeartbeatInterval >= cli.IdleTimeout {
-		cliCtx.Errorf("idle-timeout must be greater than heartbeat-interval")
+		cliCtx.Errorf("idle-timeout must be greater than heartbeat-interval (heartbeat interval: %s, idle timeout: %s)",
+			cli.HeartbeatInterval, cli.IdleTimeout)
+		return 1
+	}
+
+	if cli.NumConns < 1 {
+		cliCtx.Errorf("invalid number of connections, must be greater than 0 (provided: %d)", cli.NumConns)
 		return 1
 	}
 
@@ -140,7 +147,7 @@ func Run(ctx context.Context, args []string) int {
 		MaxVersion:        maxVersion,
 		Resolver:          resolver,
 		ReconnectPolicy:   proxycore.NewReconnectPolicy(),
-		NumConns:          1,
+		NumConns:          cli.NumConns,
 		Auth:              auth,
 		Logger:            logger,
 		HeartBeatInterval: cli.HeartbeatInterval,

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -38,7 +38,7 @@ var cli struct {
 	AstraBundle        string        `help:"Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option." short:"b" env:"ASTRA_BUNDLE"`
 	AstraToken         string        `help:"Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option." short:"t" env:"ASTRA_TOKEN"`
 	AstraDatabaseID    string        `help:"Database ID of the Astra database. Requires '--astra-token'" short:"i" env:"ASTRA_DATABASE_ID"`
-	AstraAPIURL        string        `help:"URL for the Astra API" default:"https://api.astra.datastax.com" env:"ASTRA_API_URL"`
+	AstraApiURL        string        `help:"URL for the Astra API" default:"https://api.astra.datastax.com" env:"ASTRA_API_URL"`
 	ContactPoints      []string      `help:"Contact points for cluster. Ignored if using the bundle path or token option." short:"c" env:"CONTACT_POINTS"`
 	Username           string        `help:"Username to use for authentication" short:"u" env:"USERNAME"`
 	Password           string        `help:"Password to use for authentication" short:"p" env:"PASSWORD"`
@@ -83,7 +83,7 @@ func Run(ctx context.Context, args []string) int {
 		if len(cli.AstraDatabaseID) == 0 {
 			cliCtx.Fatalf("database ID is required when using a token")
 		}
-		bundle, err := astra.LoadBundleZipFromURL(cli.AstraAPIURL, cli.AstraDatabaseID, cli.AstraToken, 10*time.Second)
+		bundle, err := astra.LoadBundleZipFromURL(cli.AstraApiURL, cli.AstraDatabaseID, cli.AstraToken, 10*time.Second)
 		if err != nil {
 			cliCtx.Fatalf("unable to load bundle %s from astra: %v", cli.AstraBundle, err)
 		}

--- a/proxycore/cluster.go
+++ b/proxycore/cluster.go
@@ -259,11 +259,13 @@ func (c *Cluster) mergeHosts(hosts []*Host) error {
 		if _, ok := existing[key]; ok {
 			delete(existing, key)
 		} else {
+			c.logger.Info("adding host to the cluster", zap.Stringer("host", host))
 			c.sendEvent(&AddEvent{host})
 		}
 	}
 
 	for _, host := range existing {
+		c.logger.Info("removing host from the cluster", zap.Stringer("host", host))
 		c.sendEvent(&RemoveEvent{host})
 	}
 

--- a/proxycore/connpool.go
+++ b/proxycore/connpool.go
@@ -183,7 +183,8 @@ func (p *connPool) stayConnected(idx int) {
 		if conn == nil {
 			if !pendingConnect {
 				delay := reconnectPolicy.NextDelay()
-				p.logger.Debug("pool connection attempting to reconnect after delay", zap.Duration("delay", delay))
+				p.logger.Info("pool connection attempting to reconnect after delay",
+					zap.Stringer("host", p.config.Endpoint), zap.Duration("delay", delay))
 				connectTimer = time.NewTimer(reconnectPolicy.NextDelay())
 				pendingConnect = true
 			} else {
@@ -193,7 +194,8 @@ func (p *connPool) stayConnected(idx int) {
 				case <-connectTimer.C:
 					c, err := p.connect()
 					if err != nil {
-						p.logger.Error("pool failed to connect", zap.Stringer("host", p.config.Endpoint), zap.Error(err))
+						p.logger.Error("pool failed to connect",
+							zap.Stringer("host", p.config.Endpoint), zap.Error(err))
 					} else {
 						p.connsMu.Lock()
 						conn, p.conns[idx] = c, c
@@ -209,6 +211,7 @@ func (p *connPool) stayConnected(idx int) {
 				done = true
 				_ = conn.Close()
 			case <-conn.IsClosed():
+				p.logger.Warn("pool closed", zap.Stringer("host", p.config.Endpoint))
 				p.connsMu.Lock()
 				conn, p.conns[idx] = nil, nil
 				p.connsMu.Unlock()

--- a/proxycore/connpool.go
+++ b/proxycore/connpool.go
@@ -194,7 +194,7 @@ func (p *connPool) stayConnected(idx int) {
 				case <-connectTimer.C:
 					c, err := p.connect()
 					if err != nil {
-						p.logger.Error("pool failed to connect",
+						p.logger.Error("pool connection failed to connect",
 							zap.Stringer("host", p.config.Endpoint), zap.Error(err))
 					} else {
 						p.connsMu.Lock()
@@ -211,7 +211,7 @@ func (p *connPool) stayConnected(idx int) {
 				done = true
 				_ = conn.Close()
 			case <-conn.IsClosed():
-				p.logger.Warn("pool closed", zap.Stringer("host", p.config.Endpoint))
+				p.logger.Info("pool connection closed", zap.Stringer("host", p.config.Endpoint))
 				p.connsMu.Lock()
 				conn, p.conns[idx] = nil, nil
 				p.connsMu.Unlock()


### PR DESCRIPTION
A small refactor of the cli flags. I've added an `astra` prefix to the Astra specific options e.g. `--astra-bundle` (`ASTRA_BUNDLE` for the env. variable).

I've also update the README for the updated options including using an Astra Token (instead of the secure connect bundle).

I haven't update the k8s instruction, but I've created a follow up ticket: https://github.com/datastax/cql-proxy/issues/77. The main reason for doing this is I'm not a fan of the current instructions because they should be putting the client secrets in the secret store instead of the command. I need to run through a setup where I use the new astra token options with the k8s secrets.