### PR TITLE
Fix initial connpool delay when a new node is added

### DIFF
--- a/proxycore/connpool.go
+++ b/proxycore/connpool.go
@@ -176,7 +176,7 @@ func (p *connPool) stayConnected(idx int) {
 
 	connectTimer := time.NewTimer(0)
 	reconnectPolicy := p.config.ReconnectPolicy.Clone()
-	pendingConnect := false
+	pendingConnect := true
 
 	done := false
 	for !done {
@@ -212,6 +212,7 @@ func (p *connPool) stayConnected(idx int) {
 				p.connsMu.Lock()
 				conn, p.conns[idx] = nil, nil
 				p.connsMu.Unlock()
+				pendingConnect = false
 			}
 		}
 	}


### PR DESCRIPTION
When a new node was added it was waiting for the first delay of the
reconnection policy before connecting. This resolves that by not having
a pending timeout as the initial state.