### PR TITLE
Try using a `bufio.Reader` in `proxycore.Conn`

### DIFF
--- a/proxycore/conn.go
+++ b/proxycore/conn.go
@@ -41,6 +41,7 @@ type Conn struct {
 	err      error
 	recv     Receiver
 	writer   *bufio.Writer
+	reader   *bufio.Reader
 	mu       *sync.Mutex
 }
 
@@ -95,6 +96,7 @@ func NewConn(conn net.Conn, recv Receiver) *Conn {
 		conn:     conn,
 		recv:     recv,
 		writer:   bufio.NewWriterSize(conn, MaxCoalesceSize),
+		reader:   bufio.NewReader(conn),
 		closed:   make(chan struct{}),
 		messages: make(chan Sender, MaxMessages),
 		mu:       &sync.Mutex{},
@@ -109,7 +111,7 @@ func (c *Conn) Start() {
 func (c *Conn) read() {
 	done := false
 	for !done {
-		done = c.checkErr(c.recv.Receive(c.conn))
+		done = c.checkErr(c.recv.Receive(c.reader))
 	}
 	c.recv.Closing(c.Err())
 }


### PR DESCRIPTION
After profiling I noticed that significant time is spent in the read system
call reading a single byte for the CQL native protocol header. It's
possible that we can eliminate some system calls by using a buffered 
reader.

![image](https://user-images.githubusercontent.com/3710715/153960056-47a2dffe-3819-4d00-bd68-675da4f84af5.png)
