### PR TITLE
Fix shutdown when proxy is killed by a signal

### DIFF
--- a/proxy/run.go
+++ b/proxy/run.go
@@ -265,6 +265,11 @@ func listenAndServe(p *Proxy, ctx context.Context, logger *zap.Logger) (err erro
 	wg.Add(numServers)
 
 	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	go func() {
 		select {
 		case <-ctx.Done():
 			logger.Debug("proxy interrupted/killed")
@@ -275,7 +280,7 @@ func listenAndServe(p *Proxy, ctx context.Context, logger *zap.Logger) (err erro
 
 	go func() {
 		defer wg.Done()
-		err = p.Serve()
+		err := p.Serve()
 		if err != nil && err != ErrProxyClosed {
 			ch <- err
 		}
@@ -284,7 +289,7 @@ func listenAndServe(p *Proxy, ctx context.Context, logger *zap.Logger) (err erro
 	if cli.HealthCheck {
 		go func() {
 			defer wg.Done()
-			err = server.Serve(listener)
+			err := server.Serve(listener)
 			if err != nil {
 				ch <- err
 			}

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -290,7 +290,7 @@ func listenAndServe(p *Proxy, ctx context.Context, logger *zap.Logger) (err erro
 		go func() {
 			defer wg.Done()
 			err := server.Serve(listener)
-			if err != nil {
+			if err != nil && err != http.ErrServerClosed {
 				ch <- err
 			}
 		}()


### PR DESCRIPTION
Tested manually via:


```
cql-proxy --contact-points 127.0.0.11 --bind 127.0.0.1:9042 --health-check
^C
# dies
```


```
cql-proxy --contact-points 127.0.0.11 --bind 127.0.0.1:9042 &
# ok
cql-proxy --contact-points 127.0.0.11 --bind 127.0.0.1:9042 &
# error
cql-proxy: error: listen tcp 127.0.0.1:9042: bind: address already in use
```

```
cql-proxy --contact-points 127.0.0.11 --bind 127.0.0.1:9042 --health-check
# ok
cql-proxy --contact-points 127.0.0.11 --bind 127.0.0.1:9043 --health-check
# error
cql-proxy: error: listen tcp :8000: bind: address already in use
```

