### PR TITLE
Multi-region (data center) proof of concept #1

### DIFF
--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -36,7 +36,7 @@ var (
 	}
 
 	SystemPeersColumns = []*message.ColumnMetadata{
-		{Keyspace: "system", Table: "peers", Name: "peer", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "peers", Name: "peer", Type: datatype.Inet},
 		{Keyspace: "system", Table: "peers", Name: "rpc_address", Type: datatype.Inet},
 		{Keyspace: "system", Table: "peers", Name: "data_center", Type: datatype.Varchar},
 		{Keyspace: "system", Table: "peers", Name: "rack", Type: datatype.Varchar},

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -642,7 +642,7 @@ func (c *client) filterSystemPeerValues(stmt *parser.SelectStatement, peer *node
 		} else if name == "tokens" {
 			return proxycore.EncodeType(datatype.NewListType(datatype.Varchar), c.proxy.cluster.NegotiatedVersion, []string{peer.token})
 		} else if name == "peer" {
-			return proxycore.EncodeType(datatype.Varchar, c.proxy.cluster.NegotiatedVersion, peer.Addr.IP.String())
+			return proxycore.EncodeType(datatype.Inet, c.proxy.cluster.NegotiatedVersion, peer.Addr.IP)
 		} else if name == "rpc_address" {
 			return proxycore.EncodeType(datatype.Inet, c.proxy.cluster.NegotiatedVersion, peer.Addr.IP)
 		} else if val, ok := c.proxy.systemLocalValues[name]; ok {

--- a/proxycore/host.go
+++ b/proxycore/host.go
@@ -14,20 +14,15 @@
 
 package proxycore
 
-import "errors"
-
 type Host struct {
 	endpoint Endpoint
 	DC       string
 }
 
 func NewHostFromRow(endpoint Endpoint, row Row) (*Host, error) {
-	val, err := row.ByName("data_center")
+	dc, err := row.StringByName("data_center")
 	if err != nil {
 		return nil, err
-	}
-	if dc, ok := val.(string); !ok {
-		return nil, errors.New("'data_center' is not a string")
 	} else {
 		return &Host{endpoint, dc}, nil
 	}

--- a/proxycore/host.go
+++ b/proxycore/host.go
@@ -14,12 +14,23 @@
 
 package proxycore
 
+import "errors"
+
 type Host struct {
 	endpoint Endpoint
+	DC       string
 }
 
-func NewHostFromRow(endpoint Endpoint, _ Row) (*Host, error) {
-	return &Host{endpoint}, nil
+func NewHostFromRow(endpoint Endpoint, row Row) (*Host, error) {
+	val, err := row.ByName("data_center")
+	if err != nil {
+		return nil, err
+	}
+	if dc, ok := val.(string); !ok {
+		return nil, errors.New("'data_center' is not a string")
+	} else {
+		return &Host{endpoint, dc}, nil
+	}
 }
 
 func (h *Host) Endpoint() Endpoint {

--- a/proxycore/resultset.go
+++ b/proxycore/resultset.go
@@ -16,6 +16,9 @@ package proxycore
 
 import (
 	"errors"
+	"fmt"
+	"net"
+
 	"github.com/datastax/go-cassandra-native-protocol/message"
 	"github.com/datastax/go-cassandra-native-protocol/primitive"
 )
@@ -70,5 +73,41 @@ func (r Row) ByName(n string) (interface{}, error) {
 		return nil, ColumnNameNotFound
 	} else {
 		return r.ByPos(i)
+	}
+}
+
+func (r Row) StringByName(n string) (string, error) {
+	val, err := r.ByName(n)
+	if err != nil {
+		return "", err
+	}
+	if s, ok := val.(string); !ok {
+		return "", fmt.Errorf("'%s' is not a string", n)
+	} else {
+		return s, nil
+	}
+}
+
+func (r Row) InetByName(n string) (net.IP, error) {
+	val, err := r.ByName(n)
+	if err != nil {
+		return nil, err
+	}
+	if ip, ok := val.(net.IP); !ok {
+		return nil, fmt.Errorf("'%s' is not an inet", n)
+	} else {
+		return ip, nil
+	}
+}
+
+func (r Row) UUIDByName(n string) (primitive.UUID, error) {
+	val, err := r.ByName(n)
+	if err != nil {
+		return [16]byte{}, err
+	}
+	if u, ok := val.(primitive.UUID); !ok {
+		return [16]byte{}, fmt.Errorf("'%s' is not a uuid", n)
+	} else {
+		return u, nil
 	}
 }


### PR DESCRIPTION
A prototype for multi-region failover using the driver's DC-aware load balancing policy.

## Setup

Created an Astra cluster in multiple regions and downloaded the secure connect bundles for each and created a token. Use these to create two cql-proxy instances, one for each region:

```
./cql-proxy --astra-bundle secure-connect-testdb-us-east1.zip  --username token --password <astra-token> --data-center dc-1 --peers "127.0.0.2;dc-2" --bind 127.0.0.1:9042 --rpc-address 127.0.0.1 &> dc1.log &

./cql-proxy --astra-bundle secure-connect-testdb-us-east4.zip  --username token --password <astra-token> --data-center dc-2 --peers "127.0.0.1;dc-1" --bind 127.0.0.2:9042 --rpc-address 127.0.0.2 &> dc2.log &
```

Some new flags added to support this:

* `--data-center`:  The data-center of this proxy. This could potentially come from the region in the metadata service JSON payload.
* `--peers`: A comma delimited list of other proxy instances. `;` is used to specify the DC of the peer, format: `<IP>[:<port>][;<datacenter>]`
* `--rpc-address`: The advertised address of the proxy to use in `sytem.local`. This might be useful outside of this prototype.

The driver is then configured to use DC aware load balancing:

```java
public class App 
{
    private static ProgrammaticDriverConfigLoaderBuilder getDriverConfigLoaderBuilder() {
        return DriverConfigLoader.programmaticBuilder()
            .withInt(DefaultDriverOption.LOAD_BALANCING_DC_FAILOVER_MAX_NODES_PER_REMOTE_DC, 1);
    }

    public static void main( String[] args ) throws InterruptedException {
        try(CqlSession session = CqlSession.builder()
            .withConfigLoader(getDriverConfigLoaderBuilder().build())
            .withLocalDatacenter("dc-1").build()) {
            while(true) {
                try {
                    ResultSet rs = session.execute(SimpleStatement
                        .newInstance("SELECT * FROM testks.test")
                        .setIdempotent(true) // It's important to tell the driver the statement is idempotent so that it can be retried
                        .setConsistencyLevel(ConsistencyLevel.ONE)); // Use a not local consistency level
                    System.out.println(rs.getExecutionInfo().getCoordinator());
                    System.out.println(Streams.stream(rs)
                        .map(r -> Integer.toString(r.getInt("k")))
                        .collect(Collectors.joining(",")));
                } catch (Exception ex) {
                    System.out.println(ex);
                } finally {
                    Thread.sleep(2000);
                }
            }
        }
    }
}
```

## Experiment

Running the proxies and the driver example above.  The proxies in the local region are blocked:

```
for ip in $(dig +answer +short  809d03f2-5b67-48bc-872d-b25dbeb70e51-us-east1.db.astra-dev.datastax.com)
do
  echo "Blocking $ip"
  iptables -A INPUT -s $ip -j DROP
done
```

and restored:

```
iptables -F
```

### Result

```sh
Node(endPoint=/127.0.0.1:9042, hostId=a862f4f4-11b8-3cdb-b811-1834ef38f53a, hashCode=728865dc)
5,1,2,4,3
# ... (using the local region)
# Block the local region
com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
# Now using the remote region
Node(endPoint=/127.0.0.2:9042, hostId=59e5256d-00e5-3988-ad26-7429d44eb84c, hashCode=5728afb7)
5,1,2,4,3
# ...
# Flush iptables 
# Move back to the local region
Node(endPoint=/127.0.0.1:9042, hostId=a862f4f4-11b8-3cdb-b811-1834ef38f53a, hashCode=728865dc)
5,1,2,4,3
```

                                                             