### PR TITLE
Ignore remote DC nodes when resolving endpoints (Astra only)

### DIFF
--- a/proxycore/cluster.go
+++ b/proxycore/cluster.go
@@ -240,7 +240,7 @@ func (c *Cluster) mergeHosts(hosts []*Host) error {
 	existing := make(map[string]*Host)
 
 	for _, host := range c.hosts {
-		existing[host.Endpoint().Key()] = host
+		existing[host.Key()] = host
 	}
 
 	c.currentHostIndex = -1
@@ -282,7 +282,6 @@ func (c *Cluster) sendEvent(event Event) {
 
 func (c *Cluster) queryHosts(ctx context.Context, conn *ClientConn, version primitive.ProtocolVersion) (hosts []*Host, info ClusterInfo, err error) {
 	var rs *ResultSet
-	var val interface{}
 
 	rs, err = conn.Query(ctx, version, &message.Query{
 		Query: "SELECT * FROM system.local",
@@ -299,23 +298,20 @@ func (c *Cluster) queryHosts(ctx context.Context, conn *ClientConn, version prim
 	hosts = c.addHosts(hosts, rs)
 	row := rs.Row(0)
 
-	val, err = row.ByName("partitioner")
+	partitioner, err := row.StringByName("partitioner")
 	if err != nil {
 		return nil, ClusterInfo{}, err
 	}
-	partitioner := val.(string)
 
-	val, err = row.ByName("release_version")
+	releaseVersion, err := row.StringByName("release_version")
 	if err != nil {
 		return nil, ClusterInfo{}, err
 	}
-	releaseVersion := val.(string)
 
-	val, err = row.ByName("cql_version")
+	cqlVersion, err := row.StringByName("cql_version")
 	if err != nil {
 		return nil, ClusterInfo{}, err
 	}
-	cqlVersion := val.(string)
 
 	rs, err = conn.Query(ctx, version, &message.Query{
 		Query: "SELECT * FROM system.peers",
@@ -341,7 +337,11 @@ func (c *Cluster) addHosts(hosts []*Host, rs *ResultSet) []*Host {
 		if endpoint, err := c.config.Resolver.NewEndpoint(row); err == nil {
 			if host, err := NewHostFromRow(endpoint, row); err == nil {
 				hosts = append(hosts, host)
+			} else {
+				c.logger.Error("unable to create new host", zap.Stringer("endpoint", endpoint), zap.Error(err))
 			}
+		} else if err != IgnoreEndpoint {
+			c.logger.Error("unable to create new endpoint", zap.Error(err))
 		}
 	}
 	return hosts
@@ -350,7 +350,7 @@ func (c *Cluster) addHosts(hosts []*Host, rs *ResultSet) []*Host {
 func (c *Cluster) reconnect() bool {
 	c.currentHostIndex = (c.currentHostIndex + 1) % len(c.hosts)
 	host := c.hosts[c.currentHostIndex]
-	err := c.connect(c.ctx, host.Endpoint(), false)
+	err := c.connect(c.ctx, host.Endpoint, false)
 	if err != nil {
 		c.logger.Error("error reconnecting to host", zap.Stringer("host", host), zap.Error(err))
 		return false

--- a/proxycore/host.go.orig
+++ b/proxycore/host.go.orig
@@ -15,17 +15,31 @@
 package proxycore
 
 type Host struct {
-	Endpoint
+	endpoint Endpoint
 }
 
-func NewHostFromRow(endpoint Endpoint, row Row) (*Host, error) {
+<<<<<<< HEAD
+func NewHostFromRow(endpoint Endpoint, _ Row) (*Host, error) {
 	return &Host{endpoint}, nil
+=======
+func NewHostFromRow(endpoint Endpoint, row Row) (*Host, error) {
+	dc, err := row.StringByName("data_center")
+	if err != nil {
+		return nil, err
+	} else {
+		return &Host{endpoint, dc}, nil
+	}
+>>>>>>> 4a77b5a... Filter endpoints that are not in the current region
+}
+
+func (h *Host) Endpoint() Endpoint {
+	return h.endpoint
 }
 
 func (h *Host) Key() string {
-	return h.Endpoint.Key()
+	return h.endpoint.Key()
 }
 
 func (h *Host) String() string {
-	return h.Endpoint.String()
+	return h.endpoint.String()
 }

--- a/proxycore/lb.go
+++ b/proxycore/lb.go
@@ -54,7 +54,7 @@ func (l *roundRobinLoadBalancer) OnEvent(event Event) {
 	case *RemoveEvent:
 		cpy := l.copy()
 		for i, h := range cpy {
-			if h.Endpoint().Key() == evt.Host.Key() {
+			if h.Key() == evt.Host.Key() {
 				l.hosts.Store(append(cpy[:i], cpy[i+1:]...))
 				break
 			}

--- a/proxycore/resultset.go
+++ b/proxycore/resultset.go
@@ -16,6 +16,9 @@ package proxycore
 
 import (
 	"errors"
+	"fmt"
+	"net"
+
 	"github.com/datastax/go-cassandra-native-protocol/message"
 	"github.com/datastax/go-cassandra-native-protocol/primitive"
 )
@@ -70,5 +73,41 @@ func (r Row) ByName(n string) (interface{}, error) {
 		return nil, ColumnNameNotFound
 	} else {
 		return r.ByPos(i)
+	}
+}
+
+func (r Row) StringByName(n string) (string, error) {
+	val, err := r.ByName(n)
+	if err != nil {
+		return "", err
+	}
+	if s, ok := val.(string); !ok {
+		return "", fmt.Errorf("'%s' is not a string", n)
+	} else {
+		return s, nil
+	}
+}
+
+func (r Row) InetByName(n string) (net.IP, error) {
+	val, err := r.ByName(n)
+	if err != nil {
+		return nil, err
+	}
+	if ip, ok := val.(net.IP); !ok {
+		return nil, fmt.Errorf("'%s' is not an inet", n)
+	} else {
+		return ip, nil
+	}
+}
+
+func (r Row) UUIDByName(n string) (primitive.UUID, error) {
+	val, err := r.ByName(n)
+	if err != nil {
+		return [16]byte{}, err
+	}
+	if u, ok := val.(primitive.UUID); !ok {
+		return [16]byte{}, fmt.Errorf("'%s' is not a uuid", n)
+	} else {
+		return u, nil
 	}
 }


### PR DESCRIPTION
Remote DC nodes require their own secure connect bundle and are unable
to be connected to. The Astra endpoint resolver will now ignore these
nodes so that it avoid attempting connections.