### PR TITLE
Add feature to configure peer proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ All configuration keys match their command-line flag counterpart, e.g. `--astra-
 
 Multi-region failover with DC-aware load balancing policy is the most useful case for a multiple proxy setup.
 
-When configuration `peers:` it is required to set `--rpc-address` (or `rpc-address:` in the yaml) for each proxy and it must match is correspond `peers:` entry. Also, `peers:` is only available in the configuration file and cannot be set using a command-line flag.
+When configuring `peers:` it is required to set `--rpc-address` (or `rpc-address:` in the yaml) for each proxy and it must match is corresponding `peers:` entry. Also, `peers:` is only available in the configuration file and cannot be set using a command-line flag.
 
 ##### Multi-region setup
 
-Here's an example of configuring multi-region failover with two proxies. A proxy is started for each region in the cluster and connects to it using that region's bundle. They all share a common configuration file that contains the full list of proxies. 
+Here's an example of configuring multi-region failover with two proxies. A proxy is started for each region of the cluster connecting to it using that region's bundle. They all share a common configuration file that contains the full list of proxies.
 
 *Note:* Only bundles are supported for multi-region setups.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ bind: 127.0.0.1:9042
 ```
 
 All configuration keys match their command-line flag counterpart, e.g. `--astra-bundle` is
-`astra-bundle`,  `--contact-points` is `contact-points` etc.
+`astra-bundle:`,  `--contact-points` is `contact-points:` etc.
 
 #### Setting up peer proxies
 

--- a/README.md
+++ b/README.md
@@ -36,29 +36,34 @@ $ ./cql-proxy -h
 Usage: cql-proxy
 
 Flags:
-  -h, --help                                 Show context-sensitive help.
-  -b, --astra-bundle=STRING                  Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option
-                                             ($ASTRA_BUNDLE).
-  -t, --astra-token=STRING                   Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option
-                                             ($ASTRA_TOKEN).
-  -i, --astra-database-id=STRING             Database ID of the Astra database. Requires '--astra-token' ($ASTRA_DATABASE_ID)
-  -c, --contact-points=CONTACT-POINTS,...    Contact points for cluster. Ignored if using the bundle path or token option ($CONTACT_POINTS).
-  -u, --username=STRING                      Username to use for authentication ($USERNAME)
-  -p, --password=STRING                      Password to use for authentication ($PASSWORD)
-  -r, --port=9042                            Default port to use when connecting to cluster ($PORT)
-  -n, --protocol-version="v4"                Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2) ($PROTOCOL_VERSION)
-  -m, --max-protocol-version="v4"            Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2) ($MAX_PROTOCOL_VERSION)
-  -a, --bind=":9042"                         Address to use to bind server ($BIND)
-      --debug                                Show debug logging ($DEBUG)
-      --health-check                         Enable liveness and readiness checks ($HEALTH_CHECK)
-      --http-bind=":8000"                    Address to use to bind HTTP server used for health checks ($HTTP_BIND)
-      --heartbeat-interval=30s               Interval between performing heartbeats to the cluster ($HEARTBEAT_INTERVAL)
-      --idle-timeout=60s                     Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed ($IDLE_TIMEOUT)
-      --readiness-timeout=30s                Duration the proxy is unable to connect to the backend cluster before it is considered not ready ($READINESS_TIMEOUT)
-      --num-conns=1                          Number of connection to create to each node of the backend cluster ($NUM_CONNS)
+  -h, --help                                              Show context-sensitive help.
+  -b, --astra-bundle=STRING                               Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option
+                                                          ($ASTRA_BUNDLE).
+  -t, --astra-token=STRING                                Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option
+                                                          ($ASTRA_TOKEN).
+  -i, --astra-database-id=STRING                          Database ID of the Astra database. Requires '--astra-token' ($ASTRA_DATABASE_ID)
+      --astra-api-url="https://api.astra.datastax.com"    URL for the Astra API ($ASTRA_API_URL)
+  -c, --contact-points=CONTACT-POINTS,...                 Contact points for cluster. Ignored if using the bundle path or token option ($CONTACT_POINTS).
+  -u, --username=STRING                                   Username to use for authentication ($USERNAME)
+  -p, --password=STRING                                   Password to use for authentication ($PASSWORD)
+  -r, --port=9042                                         Default port to use when connecting to cluster ($PORT)
+  -n, --protocol-version="v4"                             Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2) ($PROTOCOL_VERSION)
+  -m, --max-protocol-version="v4"                         Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2) ($MAX_PROTOCOL_VERSION)
+  -a, --bind=":9042"                                      Address to use to bind server ($BIND)
+  -f, --config=CONFIG                                     YAML configuration file ($CONFIG_FILE)
+      --debug                                             Show debug logging ($DEBUG)
+      --health-check                                      Enable liveness and readiness checks ($HEALTH_CHECK)
+      --http-bind=":8000"                                 Address to use to bind HTTP server used for health checks ($HTTP_BIND)
+      --heartbeat-interval=30s                            Interval between performing heartbeats to the cluster ($HEARTBEAT_INTERVAL)
+      --idle-timeout=60s                                  Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed ($IDLE_TIMEOUT)
+      --readiness-timeout=30s                             Duration the proxy is unable to connect to the backend cluster before it is considered not ready ($READINESS_TIMEOUT)
+      --num-conns=1                                       Number of connection to create to each node of the backend cluster ($NUM_CONNS)
+      --rpc-address=STRING                                Address to advertise in the 'system.local' table for 'rpc_address'. It must be set if configuring peer proxies ($RPC_ADDRESS)
+      --data-center=STRING                                Data center to use in system tables ($DATA_CENTER)
+      --tokens=TOKENS,...                                 Tokens to use in the system tables. It's not recommended ($TOKENS)
 ```
 
-To pass configuration to `cql-proxy`, either command-line flags or environment variables can be used. Using the `docker` method as an example, the following samples show how the token and database ID are defined with each method.
+To pass configuration to `cql-proxy`, either command-line flags, environment variables, or a configuration file can be used. Using the `docker` method as an example, the following samples show how the token and database ID are defined with each method.
 ### Using flags
 
 ```sh
@@ -74,6 +79,95 @@ docker run -p 9042:9042  \
   --rm datastax/cql-proxy:v0.1.1 \
   -e ASTRA_TOKEN=<astra-token> -e ASTRA_DATABASE_ID=<astra-datbase-id>
 ```
+
+### Using a configuration file
+
+Proxy settings can also be passed using a configuration file with the `--config /path/to/proxy.yaml` flag. This can be mixed and matched with command-line flags and environment variables. Here are some example configuration files:
+
+```yaml
+contact-points:
+  - 127.0.0.1
+username: cassandra
+password: cassandra
+port: 9042
+bind: 127.0.0.1:9042
+# ...
+```
+
+or with a Astra token:
+
+```yaml
+astra-token: <astra-token>
+astra-database-id: <astra-database-id>
+bind: 127.0.0.1:9042
+# ...
+```
+
+All configuration keys match their command-line flag counterpart, e.g. `--astra-bundle` is
+`astra-bundle`,  `--contact-points` is `contact-points` etc.
+
+#### Setting up peer proxies
+
+There a couple cases when it is useful to setup multiple proxies:
+* Multi-region failover with DC-aware load balancing policy. 
+* Compatibility with drivers that require a replication factor number of nodes (proxies) in a cluster for token-aware load balancing. This is not a problem for most drivers as they print a warning when there's less than replication factor nodes, and fallback to round-robin load balancing. The `gocql` driver is a notable exception, it panics when there's not enough proxies. In this case, it is best to configure the round-robin load balancing policy, but if that can't be done then multiple proxies should be used.
+
+When configuration `peers:` it is required to set `--rpc-address` (or `rpc-address:` in the yaml) for each proxy and it must match is correspond `peers:` entry. Also, `peers:` is only available in the configuration file and cannot be set using a command-line flag.
+
+##### Multi-region setup
+
+Here's an example of configuring multi-region failover with two proxies. A proxy is started for each region in the cluster and connects to it using that region's bundle. They all share a common configuration file that contains the full list of proxies. 
+
+*Note:* Only bundles are supported for multi-region setups.
+
+```sh
+cql-proxy --astra-bundle astra-region1-bundle.zip --username token --passowrd <astra-token> \
+  --bind 127.0.0.1:9042 --rpc-address 127.0.0.1 --data-center dc-1 --config proxy.yaml
+```
+
+```sh
+cql-proxy ---astra-bundle astra-region2-bundle.zip --username token --passowrd <astra-token> \
+  --bind 127.0.0.2:9042 --rpc-address 127.0.0.2 --data-center dc-2 --config proxy.yaml
+```
+
+The peers settings are configured using a yaml file. It's a good idea to explicitly provide the `--data-center` flag, otherwise; these values are pulled from the backend cluster and would need to be pulled from the `system.local` and `system.peers` table to properly setup the peers `data-center:` values. Here's an example `proxy.yaml`:
+
+```yaml
+peers:
+  - rpc-address: 127.0.0.1
+    data-center: dc-1
+  - rpc-address: 127.0.0.2
+    data-center: dc-2
+```
+
+*Note:* It's okay for the `peers:` to contain entries for the current proxy itself because they'll just be omitted.
+
+##### Token-aware bypass setup
+
+This setup is similar to the multi-region setup but is simpler because all proxy instances share the same data center value which can just use the default value (`dc1`). Replication factor is often set to `3`, so it will require creating three instances of the proxy, but this may be different for your application. 
+
+```sh
+cql-proxy --astra-token <astra-token> --astra-database-id <astra-database-id> \
+  --bind 127.0.0.1:9042 --rpc-address 127.0.0.1 --config proxy.yaml
+```
+
+```sh
+cql-proxy --astra-token <astra-token> --astra-database-id <astra-database-id> \
+1 --bind 127.0.0.2:9042 --rpc-address 127.0.0.2 --config proxy.yaml
+```
+
+```sh
+cql-proxy --astra-token <astra-token> --astra-database-id <astra-database-id> \
+  --bind 127.0.0.3:9042 --rpc-address 127.0.0.3 --config proxy.yaml
+```
+
+```yaml
+peers:
+  - rpc-address: 127.0.0.1
+  - rpc-address: 127.0.0.2
+  - rpc-address: 127.0.0.3
+```
+
 ## Getting started
 
 There are three methods for using `cql-proxy`:
@@ -100,7 +194,7 @@ There are three methods for using `cql-proxy`:
       The `<astra-token>` can be generated using these [instructions]. The proxy also supports using the [Astra Secure Connect Bundle][bundle] along with a client ID and secret generated using these [instructions]:
 
       ```
-      ./cql-proxy --bundle <your-secure-connect-zip> \
+      ./cql-proxy --astra-bundle <your-secure-connect-zip> \
       --username <astra-client-id> --password <astra-client-secret>
       ```
 

--- a/README.md
+++ b/README.md
@@ -108,9 +108,7 @@ All configuration keys match their command-line flag counterpart, e.g. `--astra-
 
 #### Setting up peer proxies
 
-There a couple cases when it is useful to setup multiple proxies:
-* Multi-region failover with DC-aware load balancing policy. 
-* Compatibility with drivers that require a replication factor number of nodes (proxies) in a cluster for token-aware load balancing. This is not a problem for most drivers as they print a warning when there's less than replication factor nodes, and fallback to round-robin load balancing. The `gocql` driver is a notable exception, it panics when there's not enough proxies. In this case, it is best to configure the round-robin load balancing policy, but if that can't be done then multiple proxies should be used.
+Multi-region failover with DC-aware load balancing policy is the most useful case for a multiple proxy setup.
 
 When configuration `peers:` it is required to set `--rpc-address` (or `rpc-address:` in the yaml) for each proxy and it must match is correspond `peers:` entry. Also, `peers:` is only available in the configuration file and cannot be set using a command-line flag.
 
@@ -141,32 +139,6 @@ peers:
 ```
 
 *Note:* It's okay for the `peers:` to contain entries for the current proxy itself because they'll just be omitted.
-
-##### Token-aware bypass setup
-
-This setup is similar to the multi-region setup but is simpler because all proxy instances share the same data center value which can just use the default value (`dc1`). Replication factor is often set to `3`, so it will require creating three instances of the proxy, but this may be different for your application. 
-
-```sh
-cql-proxy --astra-token <astra-token> --astra-database-id <astra-database-id> \
-  --bind 127.0.0.1:9042 --rpc-address 127.0.0.1 --config proxy.yaml
-```
-
-```sh
-cql-proxy --astra-token <astra-token> --astra-database-id <astra-database-id> \
-1 --bind 127.0.0.2:9042 --rpc-address 127.0.0.2 --config proxy.yaml
-```
-
-```sh
-cql-proxy --astra-token <astra-token> --astra-database-id <astra-database-id> \
-  --bind 127.0.0.3:9042 --rpc-address 127.0.0.3 --config proxy.yaml
-```
-
-```yaml
-peers:
-  - rpc-address: 127.0.0.1
-  - rpc-address: 127.0.0.2
-  - rpc-address: 127.0.0.3
-```
 
 ## Getting started
 

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,5 @@ require (
 	go.uber.org/atomic v1.8.0
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.17.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=

--- a/parser/metadata.go
+++ b/parser/metadata.go
@@ -36,7 +36,7 @@ var (
 	}
 
 	SystemPeersColumns = []*message.ColumnMetadata{
-		{Keyspace: "system", Table: "peers", Name: "peer", Type: datatype.Varchar},
+		{Keyspace: "system", Table: "peers", Name: "peer", Type: datatype.Inet},
 		{Keyspace: "system", Table: "peers", Name: "rpc_address", Type: datatype.Inet},
 		{Keyspace: "system", Table: "peers", Name: "data_center", Type: datatype.Varchar},
 		{Keyspace: "system", Table: "peers", Name: "rack", Type: datatype.Varchar},

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -55,8 +55,8 @@ const preparedIdSize = 16
 
 type PeerConfig struct {
 	RPCAddr string   `yaml:"rpc-address"`
-	DC      string   `yaml:"data-center"`
-	Tokens  []string `yaml:"tokens"`
+	DC      string   `yaml:"data-center,omitempty"`
+	Tokens  []string `yaml:"tokens,omitempty"`
 }
 
 type Config struct {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -375,11 +375,15 @@ func (p *Proxy) buildNodes() (err error) {
 			return errors.New("tokens must be provided for all peer proxies if tokens are provided for this proxy")
 		}
 		nodes = append(nodes, &node{
-			addr: addr,
-			dc:   dc,
+			addr:   addr,
+			dc:     dc,
+			tokens: peer.Tokens,
 		})
 	}
 
+	// If tokens are not provided then we calculate tokens by sorting the addresses and assigning an even portion of the
+	// ring to each proxy. This should be deterministic in multiple independent proxies, assuming they have the same
+	// list of peers.
 	if calculateTokens && len(nodes) > 1 {
 		sort.Slice(nodes, func(i, j int) bool {
 			return compareIPAddr(nodes[i].addr, nodes[j].addr) < 0

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -17,13 +17,19 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+	"math"
+	"math/big"
 	"net"
 	"reflect"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,13 +46,18 @@ import (
 )
 
 var (
-	encodedOneValue, _  = proxycore.EncodeType(datatype.Int, primitive.ProtocolVersion4, 1)
-	encodedZeroValue, _ = proxycore.EncodeType(datatype.Int, primitive.ProtocolVersion4, 0)
+	encodedOneValue, _ = proxycore.EncodeType(datatype.Int, primitive.ProtocolVersion4, 1)
 )
 
 var ErrProxyClosed = errors.New("proxy closed")
 
 const preparedIdSize = 16
+
+type PeerConfig struct {
+	RPCAddr string   `yaml:"rpc-address"`
+	DC      string   `yaml:"data-center"`
+	Tokens  []string `yaml:"tokens"`
+}
 
 type Config struct {
 	Version           primitive.ProtocolVersion
@@ -59,6 +70,10 @@ type Config struct {
 	Logger            *zap.Logger
 	HeartBeatInterval time.Duration
 	IdleTimeout       time.Duration
+	RPCAddr           string
+	DC                string
+	Tokens            []string
+	Peers             []PeerConfig
 	// PreparedCache a cache that stores prepared queries. If not set it uses the default implementation with a max
 	// capacity of ~100MB.
 	PreparedCache proxycore.PreparedCache
@@ -80,6 +95,14 @@ type Proxy struct {
 	systemLocalValues   map[string]message.Column
 	closed              chan struct{}
 	closingMu           sync.Mutex
+	localNode           *node
+	nodes               []*node
+}
+
+type node struct {
+	addr   *net.IPAddr
+	dc     string
+	tokens []string
 }
 
 func (p *Proxy) OnEvent(event proxycore.Event) {
@@ -155,6 +178,11 @@ func (p *Proxy) Listen(address string) error {
 	err = p.cluster.Listen(p)
 	if err != nil {
 		return fmt.Errorf("unable to register to listen for schema events %w", err)
+	}
+
+	err = p.buildNodes()
+	if err != nil {
+		return fmt.Errorf("unable to build node information: %w", err)
 	}
 
 	p.buildLocalRow()
@@ -288,22 +316,102 @@ func (p *Proxy) newQueryPlan() proxycore.QueryPlan {
 
 var (
 	schemaVersion, _ = primitive.ParseUuid("4f2b29e6-59b5-4e2d-8fd6-01e32e67f0d7")
-	hostId, _        = primitive.ParseUuid("19e26944-ffb1-40a9-a184-a9b065e5e06b")
 )
+
+func (p *Proxy) buildNodes() (err error) {
+	numPeers := len(p.config.Peers)
+	nodes := make([]*node, 0, numPeers+1)
+
+	var localAddr *net.IPAddr
+	if len(p.config.RPCAddr) > 0 {
+		localAddr, err = net.ResolveIPAddr("ip", p.config.RPCAddr)
+		if err != nil {
+			return fmt.Errorf("invalid RPC address: %w", err)
+		}
+	} else if numPeers > 0 {
+		return errors.New("peers provided, but RPC address is not set")
+	}
+
+	localDC := p.config.DC
+	if len(localDC) == 0 {
+		localDC = p.cluster.Info.LocalDC
+		p.logger.Info("no local DC configured using DC from the first successful contact point",
+			zap.String("dc", localDC))
+	}
+
+	var localTokens []string
+	calculateTokens := false
+	if len(p.config.Tokens) > 0 {
+		localTokens = p.config.Tokens
+	} else {
+		calculateTokens = true
+		localTokens = []string{strconv.FormatInt(math.MinInt64, 10)}
+	}
+
+	p.localNode = &node{
+		addr:   localAddr,
+		dc:     localDC,
+		tokens: localTokens,
+	}
+	nodes = append(nodes, p.localNode)
+
+	for i, peer := range p.config.Peers {
+		if len(peer.RPCAddr) == 0 {
+			return fmt.Errorf("no 'rpc-address' provided for peer #%d", i+1)
+		}
+		addr, err := net.ResolveIPAddr("ip", peer.RPCAddr)
+		if err != nil {
+			return fmt.Errorf("invalid peer address: %w", err)
+		}
+		if compareIPAddr(localAddr, addr) == 0 {
+			p.logger.Info("ignoring local address in peers configuration", zap.Stringer("localAddr", localAddr))
+			continue
+		}
+		dc := peer.DC
+		if len(dc) == 0 {
+			dc = localDC
+		}
+		if !calculateTokens && len(peer.Tokens) == 0 {
+			return errors.New("tokens must be provided for all peer proxies if tokens are provided for this proxy")
+		}
+		nodes = append(nodes, &node{
+			addr: addr,
+			dc:   dc,
+		})
+	}
+
+	if calculateTokens && len(nodes) > 1 {
+		sort.Slice(nodes, func(i, j int) bool {
+			return compareIPAddr(nodes[i].addr, nodes[j].addr) < 0
+		})
+
+		var numTokens big.Int
+		numTokens.SetUint64(math.MaxUint64/uint64(numPeers+1) + 1)
+		start := big.NewInt(math.MinInt64)
+
+		for _, n := range nodes {
+			n.tokens = []string{start.Text(10)}
+			start.Add(start, &numTokens)
+		}
+	}
+
+	p.nodes = nodes
+
+	return nil
+}
 
 func (p *Proxy) buildLocalRow() {
 	p.systemLocalValues = map[string]message.Column{
 		"key":                     p.encodeTypeFatal(datatype.Varchar, "local"),
-		"data_center":             p.encodeTypeFatal(datatype.Varchar, "dc1"),
+		"data_center":             p.encodeTypeFatal(datatype.Varchar, p.localNode.dc),
 		"rack":                    p.encodeTypeFatal(datatype.Varchar, "rack1"),
-		"tokens":                  p.encodeTypeFatal(datatype.NewListType(datatype.Varchar), []string{"0"}),
+		"tokens":                  p.encodeTypeFatal(datatype.NewListType(datatype.Varchar), p.localNode.tokens),
 		"release_version":         p.encodeTypeFatal(datatype.Varchar, p.cluster.Info.ReleaseVersion),
 		"partitioner":             p.encodeTypeFatal(datatype.Varchar, p.cluster.Info.Partitioner),
 		"cluster_name":            p.encodeTypeFatal(datatype.Varchar, "cql-proxy"),
 		"cql_version":             p.encodeTypeFatal(datatype.Varchar, p.cluster.Info.CQLVersion),
 		"schema_version":          p.encodeTypeFatal(datatype.Uuid, schemaVersion), // TODO: Make this match the downstream cluster(s)
 		"native_protocol_version": p.encodeTypeFatal(datatype.Varchar, p.cluster.NegotiatedVersion.String()),
-		"host_id":                 p.encodeTypeFatal(datatype.Uuid, hostId),
 	}
 }
 
@@ -508,33 +616,53 @@ func (c *client) handleQuery(raw *frame.RawFrame, msg *partialQuery) {
 	}
 }
 
-func (c *client) columnValue(values map[string]message.Column, name string, table string) message.Column {
-	var val message.Column
-	var ok bool
-	if val, ok = values[name]; !ok {
-		if name == "rpc_address" && table == "local" {
-			switch addr := c.conn.LocalAddr().(type) {
-			case *net.TCPAddr:
-				val, _ = proxycore.EncodeType(datatype.Inet, c.proxy.cluster.NegotiatedVersion, addr.IP)
-			}
-		}
-	}
-	return val
-}
-
 func (c *client) filterSystemLocalValues(stmt *parser.SelectStatement) (row []message.Column, err error) {
 	return parser.FilterValues(stmt, parser.SystemLocalColumns, func(name string) (value message.Column, err error) {
-		if val, ok := c.proxy.systemLocalValues[name]; ok {
+		if name == "rpc_address" {
+			return proxycore.EncodeType(datatype.Inet, c.proxy.cluster.NegotiatedVersion, c.localIP())
+		} else if name == "host_id" {
+			return proxycore.EncodeType(datatype.Uuid, c.proxy.cluster.NegotiatedVersion, nameBasedUUID(c.localIP().String()))
+		} else if val, ok := c.proxy.systemLocalValues[name]; ok {
 			return val, nil
-		} else if name == "rpc_address" {
-			switch addr := c.conn.LocalAddr().(type) {
-			case *net.TCPAddr:
-				return proxycore.EncodeType(datatype.Inet, c.proxy.cluster.NegotiatedVersion, addr.IP)
-			default:
-				return nil, errors.New("unhandled local address type")
-			}
 		} else if name == parser.CountValueName {
 			return encodedOneValue, nil
+		} else {
+			return nil, fmt.Errorf("no column value for %s", name)
+		}
+	})
+}
+
+func (c *client) localIP() net.IP {
+	if c.proxy.localNode.addr != nil {
+		return c.proxy.localNode.addr.IP
+	} else {
+		switch a := c.conn.LocalAddr().(type) {
+		case *net.TCPAddr:
+			return a.IP
+		case *net.IPAddr:
+			return a.IP
+		default:
+			panic("unhandled local address type")
+		}
+	}
+}
+
+func (c *client) filterSystemPeerValues(stmt *parser.SelectStatement, peer *node, peerCount int) (row []message.Column, err error) {
+	return parser.FilterValues(stmt, parser.SystemPeersColumns, func(name string) (value message.Column, err error) {
+		if name == "data_center" {
+			return proxycore.EncodeType(datatype.Varchar, c.proxy.cluster.NegotiatedVersion, peer.dc)
+		} else if name == "host_id" {
+			return proxycore.EncodeType(datatype.Uuid, c.proxy.cluster.NegotiatedVersion, nameBasedUUID(peer.addr.String()))
+		} else if name == "tokens" {
+			return proxycore.EncodeType(datatype.NewListType(datatype.Varchar), c.proxy.cluster.NegotiatedVersion, peer.tokens)
+		} else if name == "peer" {
+			return proxycore.EncodeType(datatype.Inet, c.proxy.cluster.NegotiatedVersion, peer.addr.IP)
+		} else if name == "rpc_address" {
+			return proxycore.EncodeType(datatype.Inet, c.proxy.cluster.NegotiatedVersion, peer.addr.IP)
+		} else if val, ok := c.proxy.systemLocalValues[name]; ok {
+			return val, nil
+		} else if name == parser.CountValueName {
+			return proxycore.EncodeType(datatype.Int, c.proxy.cluster.NegotiatedVersion, peerCount)
 		} else {
 			return nil, fmt.Errorf("no column value for %s", name)
 		}
@@ -563,16 +691,27 @@ func (c *client) interceptSystemQuery(hdr *frame.Header, stmt interface{}) {
 				c.send(hdr, &message.Invalid{ErrorMessage: err.Error()})
 			} else {
 				var data []message.Row
-				if parser.IsCountStarQuery(s) { // COUNT(*) always returns a value, even when there are no rows
-					data = []message.Row{{encodedZeroValue}}
+				for _, n := range c.proxy.nodes {
+					if n != c.proxy.localNode {
+						var row message.Row
+						row, err = c.filterSystemPeerValues(s, n, len(c.proxy.nodes)-1)
+						if err != nil {
+							break
+						}
+						data = append(data, row)
+					}
 				}
-				c.send(hdr, &message.RowsResult{
-					Metadata: &message.RowsMetadata{
-						ColumnCount: int32(len(columns)),
-						Columns:     columns,
-					},
-					Data: data,
-				})
+				if err != nil {
+					c.send(hdr, &message.Invalid{ErrorMessage: err.Error()})
+				} else {
+					c.send(hdr, &message.RowsResult{
+						Metadata: &message.RowsMetadata{
+							ColumnCount: int32(len(columns)),
+							Columns:     columns,
+						},
+						Data: data,
+					})
+				}
 			}
 		} else if columns, ok := parser.SystemColumnsByName[s.Table]; ok {
 			c.send(hdr, &message.RowsResult{
@@ -641,4 +780,37 @@ func preparedIdKey(bytes []byte) [preparedIdSize]byte {
 	var buf [preparedIdSize]byte
 	copy(buf[:], bytes)
 	return buf
+}
+
+func nameBasedUUID(name string) primitive.UUID {
+	var uuid primitive.UUID
+	m := crypto.MD5.New()
+	_, _ = io.WriteString(m, name)
+	hash := m.Sum(nil)
+	for i := 0; i < len(uuid); i++ {
+		uuid[i] = hash[i]
+	}
+	uuid[6] &= 0x0F
+	uuid[6] |= 0x30
+	uuid[8] &= 0x3F
+	uuid[8] |= 0x80
+	return uuid
+}
+
+func compareIPAddr(a *net.IPAddr, b *net.IPAddr) int {
+	if a == b {
+		return 0
+	}
+
+	res := bytes.Compare(a.IP, b.IP)
+	if res != 0 {
+		return res
+	}
+
+	res = strings.Compare(a.Zone, b.Zone)
+	if res != 0 {
+		return res
+	}
+
+	return 0
 }

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -29,30 +31,36 @@ import (
 	"github.com/datastax/cql-proxy/proxycore"
 	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 )
 
 const livenessPath = "/liveness"
 const readinessPath = "/readiness"
 
-var cli struct {
-	AstraBundle        string        `help:"Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option." short:"b" env:"ASTRA_BUNDLE"`
-	AstraToken         string        `help:"Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option." short:"t" env:"ASTRA_TOKEN"`
-	AstraDatabaseID    string        `help:"Database ID of the Astra database. Requires '--astra-token'" short:"i" env:"ASTRA_DATABASE_ID"`
-	AstraApiURL        string        `help:"URL for the Astra API" default:"https://api.astra.datastax.com" env:"ASTRA_API_URL"`
-	ContactPoints      []string      `help:"Contact points for cluster. Ignored if using the bundle path or token option." short:"c" env:"CONTACT_POINTS"`
-	Username           string        `help:"Username to use for authentication" short:"u" env:"USERNAME"`
-	Password           string        `help:"Password to use for authentication" short:"p" env:"PASSWORD"`
-	Port               int           `help:"Default port to use when connecting to cluster" default:"9042" short:"r" env:"PORT"`
-	ProtocolVersion    string        `help:"Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"n" env:"PROTOCOL_VERSION"`
-	MaxProtocolVersion string        `help:"Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"m" env:"MAX_PROTOCOL_VERSION"`
-	Bind               string        `help:"Address to use to bind server" short:"a" default:":9042" env:"BIND"`
-	Debug              bool          `help:"Show debug logging" default:"false" env:"DEBUG"`
-	HealthCheck        bool          `help:"Enable liveness and readiness checks" default:"false" env:"HEALTH_CHECK"`
-	HttpBind           string        `help:"Address to use to bind HTTP server used for health checks" default:":8000" env:"HTTP_BIND"`
-	HeartbeatInterval  time.Duration `help:"Interval between performing heartbeats to the cluster" default:"30s" env:"HEARTBEAT_INTERVAL"`
-	IdleTimeout        time.Duration `help:"Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed" default:"60s" env:"IDLE_TIMEOUT"`
-	ReadinessTimeout   time.Duration `help:"Duration the proxy is unable to connect to the backend cluster before it is considered not ready" default:"30s" env:"READINESS_TIMEOUT"`
-	NumConns           int           `help:"Number of connection to create to each node of the backend cluster" default:"1" env:"NUM_CONNS"`
+var config struct {
+	AstraBundle        string        `yaml:"astra-bundle" help:"Path to secure connect bundle for an Astra database. Requires '--username' and '--password'. Ignored if using the token or contact points option." short:"b" env:"ASTRA_BUNDLE"`
+	AstraToken         string        `yaml:"astra-token" help:"Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option." short:"t" env:"ASTRA_TOKEN"`
+	AstraDatabaseID    string        `yaml:"astra-database-id" help:"Database ID of the Astra database. Requires '--astra-token'" short:"i" env:"ASTRA_DATABASE_ID"`
+	AstraApiURL        string        `yaml:"astra-api-url" help:"URL for the Astra API" default:"https://api.astra.datastax.com" env:"ASTRA_API_URL"`
+	ContactPoints      []string      `yaml:"contact-points" help:"Contact points for cluster. Ignored if using the bundle path or token option." short:"c" env:"CONTACT_POINTS"`
+	Username           string        `yaml:"username" help:"Username to use for authentication" short:"u" env:"USERNAME"`
+	Password           string        `yaml:"password" help:"Password to use for authentication" short:"p" env:"PASSWORD"`
+	Port               int           `yaml:"port" help:"Default port to use when connecting to cluster" default:"9042" short:"r" env:"PORT"`
+	ProtocolVersion    string        `yaml:"protocol-version" help:"Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"n" env:"PROTOCOL_VERSION"`
+	MaxProtocolVersion string        `yaml:"max-protocol-version" help:"Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"m" env:"MAX_PROTOCOL_VERSION"`
+	Bind               string        `yaml:"bind" help:"Address to use to bind server" short:"a" default:":9042" env:"BIND"`
+	Config             *os.File      `yaml:"-" help:"YAML configuration file" short:"f" env:"CONFIG_FILE"`
+	Debug              bool          `yaml:"debug" help:"Show debug logging" default:"false" env:"DEBUG"`
+	HealthCheck        bool          `yaml:"health-check" help:"Enable liveness and readiness checks" default:"false" env:"HEALTH_CHECK"`
+	HttpBind           string        `yaml:"http-bind" help:"Address to use to bind HTTP server used for health checks" default:":8000" env:"HTTP_BIND"`
+	HeartbeatInterval  time.Duration `yaml:"heartbeat-interval" help:"Interval between performing heartbeats to the cluster" default:"30s" env:"HEARTBEAT_INTERVAL"`
+	IdleTimeout        time.Duration `yaml:"idle-timeout" help:"Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed" default:"60s" env:"IDLE_TIMEOUT"`
+	ReadinessTimeout   time.Duration `yaml:"readiness-timeout" help:"Duration the proxy is unable to connect to the backend cluster before it is considered not ready" default:"30s" env:"READINESS_TIMEOUT"`
+	NumConns           int           `yaml:"num-conns" help:"Number of connection to create to each node of the backend cluster" default:"1" env:"NUM_CONNS"`
+	RpcAddress         string        `yaml:"rpc-address" help:"Address to advertise in the 'system.local' table for 'rpc_address'" env:"RPC_ADDRESS"`
+	DataCenter         string        `yaml:"data-center" help:"Data center to use in system tables" env:"DATA_CENTER"`
+	Tokens             []string      `yaml:"tokens" help:"Tokens to use in the system tables. It's not recommended" env:"TOKENS"`
+	Peers              []PeerConfig  `yaml:"peers" kong:"-"` // Not available as a CLI flag
 }
 
 // Run starts the proxy command. 'args' shouldn't include the executable (i.e. os.Args[1:]). It returns the exit code
@@ -60,64 +68,76 @@ var cli struct {
 func Run(ctx context.Context, args []string) int {
 	var err error
 
-	parser, err := kong.New(&cli)
+	parser, err := kong.New(&config)
 	if err != nil {
 		panic(err)
 	}
 
 	var cliCtx *kong.Context
 	if cliCtx, err = parser.Parse(args); err != nil {
-		parser.Errorf("error parsing cli: %v", err)
+		parser.Errorf("error parsing flags: %v", err)
 		return 1
 	}
 
+	if config.Config != nil {
+		bytes, err := io.ReadAll(config.Config)
+		if err != nil {
+			cliCtx.Errorf("unable to read contents of configuration file '%s': ", config.Config.Name(), err)
+			return 1
+		}
+		err = yaml.Unmarshal(bytes, &config)
+		if err != nil {
+			cliCtx.Errorf("invalid YAML in configuration file '%s': ", config.Config.Name(), err)
+		}
+	}
+
 	var resolver proxycore.EndpointResolver
-	if len(cli.AstraBundle) > 0 {
-		if bundle, err := astra.LoadBundleZipFromPath(cli.AstraBundle); err != nil {
-			cliCtx.Errorf("unable to open bundle %s from file: %v", cli.AstraBundle, err)
+	if len(config.AstraBundle) > 0 {
+		if bundle, err := astra.LoadBundleZipFromPath(config.AstraBundle); err != nil {
+			cliCtx.Errorf("unable to open bundle %s from file: %v", config.AstraBundle, err)
 			return 1
 		} else {
 			resolver = astra.NewResolver(bundle)
 		}
-	} else if len(cli.AstraToken) > 0 {
-		if len(cli.AstraDatabaseID) == 0 {
+	} else if len(config.AstraToken) > 0 {
+		if len(config.AstraDatabaseID) == 0 {
 			cliCtx.Fatalf("database ID is required when using a token")
 		}
-		bundle, err := astra.LoadBundleZipFromURL(cli.AstraApiURL, cli.AstraDatabaseID, cli.AstraToken, 10*time.Second)
+		bundle, err := astra.LoadBundleZipFromURL(config.AstraApiURL, config.AstraDatabaseID, config.AstraToken, 10*time.Second)
 		if err != nil {
-			cliCtx.Fatalf("unable to load bundle %s from astra: %v", cli.AstraBundle, err)
+			cliCtx.Fatalf("unable to load bundle %s from astra: %v", config.AstraBundle, err)
 		}
 		resolver = astra.NewResolver(bundle)
-		cli.Username = "token"
-		cli.Password = cli.AstraToken
-	} else if len(cli.ContactPoints) > 0 {
-		resolver = proxycore.NewResolverWithDefaultPort(cli.ContactPoints, cli.Port)
+		config.Username = "token"
+		config.Password = config.AstraToken
+	} else if len(config.ContactPoints) > 0 {
+		resolver = proxycore.NewResolverWithDefaultPort(config.ContactPoints, config.Port)
 	} else {
 		cliCtx.Errorf("must provide either bundle path, token, or contact points")
 		return 1
 	}
 
-	if cli.HeartbeatInterval >= cli.IdleTimeout {
+	if config.HeartbeatInterval >= config.IdleTimeout {
 		cliCtx.Errorf("idle-timeout must be greater than heartbeat-interval (heartbeat interval: %s, idle timeout: %s)",
-			cli.HeartbeatInterval, cli.IdleTimeout)
+			config.HeartbeatInterval, config.IdleTimeout)
 		return 1
 	}
 
-	if cli.NumConns < 1 {
-		cliCtx.Errorf("invalid number of connections, must be greater than 0 (provided: %d)", cli.NumConns)
+	if config.NumConns < 1 {
+		cliCtx.Errorf("invalid number of connections, must be greater than 0 (provided: %d)", config.NumConns)
 		return 1
 	}
 
 	var ok bool
 	var version primitive.ProtocolVersion
-	if version, ok = parseProtocolVersion(cli.ProtocolVersion); !ok {
-		cliCtx.Errorf("unsupported protocol version: %s", cli.ProtocolVersion)
+	if version, ok = parseProtocolVersion(config.ProtocolVersion); !ok {
+		cliCtx.Errorf("unsupported protocol version: %s", config.ProtocolVersion)
 		return 1
 	}
 
 	var maxVersion primitive.ProtocolVersion
-	if maxVersion, ok = parseProtocolVersion(cli.MaxProtocolVersion); !ok {
-		cliCtx.Errorf("unsupported max protocol version: %s", cli.ProtocolVersion)
+	if maxVersion, ok = parseProtocolVersion(config.MaxProtocolVersion); !ok {
+		cliCtx.Errorf("unsupported max protocol version: %s", config.ProtocolVersion)
 		return 1
 	}
 
@@ -127,7 +147,7 @@ func Run(ctx context.Context, args []string) int {
 	}
 
 	var logger *zap.Logger
-	if cli.Debug {
+	if config.Debug {
 		logger, err = zap.NewDevelopment()
 	} else {
 		logger, err = zap.NewProduction()
@@ -139,8 +159,8 @@ func Run(ctx context.Context, args []string) int {
 
 	var auth proxycore.Authenticator
 
-	if len(cli.Username) > 0 || len(cli.Password) > 0 {
-		auth = proxycore.NewPasswordAuth(cli.Username, cli.Password)
+	if len(config.Username) > 0 || len(config.Password) > 0 {
+		auth = proxycore.NewPasswordAuth(config.Username, config.Password)
 	}
 
 	p := NewProxy(ctx, Config{
@@ -148,15 +168,19 @@ func Run(ctx context.Context, args []string) int {
 		MaxVersion:        maxVersion,
 		Resolver:          resolver,
 		ReconnectPolicy:   proxycore.NewReconnectPolicy(),
-		NumConns:          cli.NumConns,
+		NumConns:          config.NumConns,
 		Auth:              auth,
 		Logger:            logger,
-		HeartBeatInterval: cli.HeartbeatInterval,
-		IdleTimeout:       cli.IdleTimeout,
+		HeartBeatInterval: config.HeartbeatInterval,
+		IdleTimeout:       config.IdleTimeout,
+		RPCAddr:           config.RpcAddress,
+		DC:                config.DataCenter,
+		Tokens:            config.Tokens,
+		Peers:             config.Peers,
 	})
 
-	cli.Bind = maybeAddPort(cli.Bind, "9042")
-	cli.HttpBind = maybeAddPort(cli.HttpBind, "8000")
+	config.Bind = maybeAddPort(config.Bind, "9042")
+	config.HttpBind = maybeAddPort(config.HttpBind, "8000")
 
 	maybeAddHealthCheck(p)
 
@@ -188,9 +212,9 @@ func parseProtocolVersion(s string) (version primitive.ProtocolVersion, ok bool)
 	return version, ok
 }
 
-// maybeAddHealthCheck checks the cli flag and adds handlers for health checks if required.
+// maybeAddHealthCheck checks the config and adds handlers for health checks if required.
 func maybeAddHealthCheck(p *Proxy) {
-	if cli.HealthCheck {
+	if config.HealthCheck {
 		http.HandleFunc(livenessPath, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 			_, _ = writer.Write([]byte("ok"))
@@ -208,7 +232,7 @@ func maybeAddHealthCheck(p *Proxy) {
 				return
 			}
 
-			if outageDuration < cli.ReadinessTimeout {
+			if outageDuration < config.ReadinessTimeout {
 				writer.WriteHeader(http.StatusOK)
 				_, _ = writer.Write(response)
 			} else {
@@ -232,23 +256,23 @@ func listenAndServe(p *Proxy, ctx context.Context, logger *zap.Logger) (err erro
 	var wg sync.WaitGroup
 
 	ch := make(chan error)
-	server := http.Server{Addr: cli.HttpBind}
+	server := http.Server{Addr: config.HttpBind}
 
 	numServers := 1 // Without the HTTP server
 
 	// Listen is called first to set up the listening server connection and establish initial client connections to the
 	// backend cluster so that when the readiness check is hit the proxy is actually ready.
-	err = p.Listen(cli.Bind)
+	err = p.Listen(config.Bind)
 	if err != nil {
 		return err
 	}
 
 	var listener *net.TCPListener
 
-	if cli.HealthCheck {
+	if config.HealthCheck {
 		numServers++ // Add the HTTP server
 
-		tcpAddr, err := net.ResolveTCPAddr("tcp", cli.HttpBind)
+		tcpAddr, err := net.ResolveTCPAddr("tcp", config.HttpBind)
 		if err != nil {
 			return err
 		}
@@ -258,8 +282,8 @@ func listenAndServe(p *Proxy, ctx context.Context, logger *zap.Logger) (err erro
 		}
 
 		logger.Info("health checks are listening",
-			zap.String("livenessURL", cli.HttpBind+livenessPath),
-			zap.String("readinessURL", cli.HttpBind+readinessPath))
+			zap.String("livenessURL", config.HttpBind+livenessPath),
+			zap.String("readinessURL", config.HttpBind+readinessPath))
 	}
 
 	wg.Add(numServers)
@@ -286,7 +310,7 @@ func listenAndServe(p *Proxy, ctx context.Context, logger *zap.Logger) (err erro
 		}
 	}()
 
-	if cli.HealthCheck {
+	if config.HealthCheck {
 		go func() {
 			defer wg.Done()
 			err := server.Serve(listener)

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -82,12 +82,12 @@ func Run(ctx context.Context, args []string) int {
 	if config.Config != nil {
 		bytes, err := io.ReadAll(config.Config)
 		if err != nil {
-			cliCtx.Errorf("unable to read contents of configuration file '%s': ", config.Config.Name(), err)
+			cliCtx.Errorf("unable to read contents of configuration file '%s': %v", config.Config.Name(), err)
 			return 1
 		}
 		err = yaml.Unmarshal(bytes, &config)
 		if err != nil {
-			cliCtx.Errorf("invalid YAML in configuration file '%s': ", config.Config.Name(), err)
+			cliCtx.Errorf("invalid YAML in configuration file '%s': %v", config.Config.Name(), err)
 		}
 	}
 

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -80,7 +80,7 @@ func Run(ctx context.Context, args []string) int {
 	}
 
 	if config.Config != nil {
-		bytes, err := io.ReadAll(config.Config)
+		bytes, err := ioutil.ReadAll(config.Config)
 		if err != nil {
 			cliCtx.Errorf("unable to read contents of configuration file '%s': %v", config.Config.Name(), err)
 			return 1

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -49,7 +49,7 @@ var config struct {
 	ProtocolVersion    string        `yaml:"protocol-version" help:"Initial protocol version to use when connecting to the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"n" env:"PROTOCOL_VERSION"`
 	MaxProtocolVersion string        `yaml:"max-protocol-version" help:"Max protocol version supported by the backend cluster (default: v4, options: v3, v4, v5, DSEv1, DSEv2)" default:"v4" short:"m" env:"MAX_PROTOCOL_VERSION"`
 	Bind               string        `yaml:"bind" help:"Address to use to bind server" short:"a" default:":9042" env:"BIND"`
-	Config             *os.File      `yaml:"-" help:"YAML configuration file" short:"f" env:"CONFIG_FILE"`
+	Config             *os.File      `yaml:"-" help:"YAML configuration file" short:"f" env:"CONFIG_FILE"` // Not available in the configuration file
 	Debug              bool          `yaml:"debug" help:"Show debug logging" default:"false" env:"DEBUG"`
 	HealthCheck        bool          `yaml:"health-check" help:"Enable liveness and readiness checks" default:"false" env:"HEALTH_CHECK"`
 	HttpBind           string        `yaml:"http-bind" help:"Address to use to bind HTTP server used for health checks" default:":8000" env:"HTTP_BIND"`

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -57,7 +57,7 @@ var config struct {
 	IdleTimeout        time.Duration `yaml:"idle-timeout" help:"Duration between successful heartbeats before a connection to the cluster is considered unresponsive and closed" default:"60s" env:"IDLE_TIMEOUT"`
 	ReadinessTimeout   time.Duration `yaml:"readiness-timeout" help:"Duration the proxy is unable to connect to the backend cluster before it is considered not ready" default:"30s" env:"READINESS_TIMEOUT"`
 	NumConns           int           `yaml:"num-conns" help:"Number of connection to create to each node of the backend cluster" default:"1" env:"NUM_CONNS"`
-	RpcAddress         string        `yaml:"rpc-address" help:"Address to advertise in the 'system.local' table for 'rpc_address'" env:"RPC_ADDRESS"`
+	RpcAddress         string        `yaml:"rpc-address" help:"Address to advertise in the 'system.local' table for 'rpc_address'. It must be set if configuring peer proxies" env:"RPC_ADDRESS"`
 	DataCenter         string        `yaml:"data-center" help:"Data center to use in system tables" env:"DATA_CENTER"`
 	Tokens             []string      `yaml:"tokens" help:"Tokens to use in the system tables. It's not recommended" env:"TOKENS"`
 	Peers              []PeerConfig  `yaml:"peers" kong:"-"` // Not available as a CLI flag

--- a/proxy/run_test.go
+++ b/proxy/run_test.go
@@ -26,8 +26,11 @@ import (
 	"time"
 
 	"github.com/datastax/cql-proxy/proxycore"
+	"github.com/datastax/go-cassandra-native-protocol/message"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -84,6 +87,190 @@ func TestRun_HealthChecks(t *testing.T) {
 		outage, status = checkReadiness(t)
 		return outage == 0 && status == http.StatusOK
 	})
+}
+
+func TestRun_ConfigFileWithPeers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster := proxycore.NewMockCluster(net.ParseIP(testClusterStartIP), testClusterPort)
+
+	err := cluster.Add(ctx, 1)
+	require.NoError(t, err)
+
+	defer cluster.Shutdown()
+
+	configFileName, err := writeTempYaml(struct {
+		Bind          string
+		Port          int
+		RPCAddr       string   `yaml:"rpc-address"`
+		DataCenter    string   `yaml:"data-center"`
+		ContactPoints []string `yaml:"contact-points"`
+		HealthCheck   bool     `yaml:"health-check"`
+		HttpBind      string   `yaml:"http-bind"`
+		Peers         []PeerConfig
+	}{
+		Bind:          "127.0.0.1:9042",
+		RPCAddr:       "127.0.0.1",
+		DataCenter:    "dc-1",
+		Port:          testClusterPort,
+		ContactPoints: []string{testClusterContactPoint},
+		HealthCheck:   true,
+		HttpBind:      testProxyHTTPBind,
+		Peers: []PeerConfig{{
+			RPCAddr: "127.0.0.1",
+			DC:      "dc-1",
+		}, {
+			RPCAddr: "127.0.0.2",
+			DC:      "dc-2",
+		}},
+	})
+
+	go func() {
+		rc := Run(ctx, []string{
+			"--config", configFileName,
+		})
+		require.Equal(t, 0, rc)
+	}()
+
+	waitUntil(10*time.Second, func() bool {
+		res, err := http.Get(fmt.Sprintf("http://%s%s", testProxyHTTPBind, livenessPath))
+		return err == nil && res.StatusCode == http.StatusOK
+	})
+
+	cl := connectTestClient(t, ctx)
+
+	rs, err := cl.Query(ctx, primitive.ProtocolVersion4, &message.Query{
+		Query: "SELECT rpc_address, data_center, tokens FROM system.local",
+	})
+	require.Equal(t, rs.RowCount(), 1)
+
+	rpcAddress, err := rs.Row(0).InetByName("rpc_address")
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", rpcAddress.String())
+
+	dataCenter, err := rs.Row(0).StringByName("data_center")
+	require.NoError(t, err)
+	assert.Equal(t, "dc-1", dataCenter)
+
+	val, err := rs.Row(0).ByName("tokens")
+	require.NoError(t, err)
+	tokens := val.([]*string)
+	assert.NotEmpty(t, tokens)
+	assert.Equal(t, "-9223372036854775808", *tokens[0])
+
+	rs, err = cl.Query(ctx, primitive.ProtocolVersion4, &message.Query{
+		Query: "SELECT rpc_address, data_center, tokens FROM system.peers",
+	})
+	require.Equal(t, rs.RowCount(), 1)
+
+	rpcAddress, err = rs.Row(0).InetByName("rpc_address")
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.2", rpcAddress.String())
+
+	dataCenter, err = rs.Row(0).StringByName("data_center")
+	require.NoError(t, err)
+	assert.Equal(t, "dc-2", dataCenter)
+
+	val, err = rs.Row(0).ByName("tokens")
+	require.NoError(t, err)
+	tokens = val.([]*string)
+	assert.NotEmpty(t, tokens)
+	assert.Equal(t, "-3074457345618258602", *tokens[0])
+}
+
+func TestRun_ConfigFileWithPeersAndNoRPCAddr(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster := proxycore.NewMockCluster(net.ParseIP(testClusterStartIP), testClusterPort)
+
+	err := cluster.Add(ctx, 1)
+	require.NoError(t, err)
+
+	defer cluster.Shutdown()
+
+	configFileName, err := writeTempYaml(struct {
+		Bind          string
+		Port          int
+		RPCAddr       string   `yaml:"rpc-address"`
+		DataCenter    string   `yaml:"data-center"`
+		ContactPoints []string `yaml:"contact-points"`
+		Peers         []PeerConfig
+	}{
+		ContactPoints: []string{testClusterContactPoint},
+		Port:          testClusterPort,
+		Bind:          "127.0.0.1:9042",
+		// No RPC address, but using peers
+		Peers: []PeerConfig{{
+			RPCAddr: "127.0.0.2",
+			DC:      "dc-2",
+		}},
+	})
+	require.NoError(t, err)
+
+	rc := Run(ctx, []string{
+		"--config", configFileName,
+	})
+	require.Equal(t, 1, rc)
+}
+
+func TestRun_ConfigFileWithInvalidPeer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cluster := proxycore.NewMockCluster(net.ParseIP(testClusterStartIP), testClusterPort)
+
+	err := cluster.Add(ctx, 1)
+	require.NoError(t, err)
+
+	defer cluster.Shutdown()
+
+	configFileName, err := writeTempYaml(struct {
+		Bind          string
+		Port          int
+		RPCAddr       string   `yaml:"rpc-address"`
+		DataCenter    string   `yaml:"data-center"`
+		ContactPoints []string `yaml:"contact-points"`
+		HealthCheck   bool     `yaml:"health-check"`
+		HttpBind      string   `yaml:"http-bind"`
+		Peers         []PeerConfig
+	}{
+		ContactPoints: []string{"127.0.0.1"},
+		Bind:          "127.0.0.1:9042",
+		RPCAddr:       "127.0.0.1",
+		Port:          testClusterPort,
+		Peers: []PeerConfig{{
+			RPCAddr: "", // Empty
+			DC:      "dc-2",
+		}},
+	})
+	require.NoError(t, err)
+
+	rc := Run(ctx, []string{
+		"--config", configFileName,
+	})
+	require.Equal(t, 1, rc)
+}
+
+func writeTempYaml(o interface{}) (name string, err error) {
+	bytes, err := yaml.Marshal(o)
+	if err != nil {
+		return "", err
+	}
+
+	f, err := ioutil.TempFile("", "cql-proxy-yaml")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	_, err = f.Write(bytes)
+	if err != nil {
+		return "", err
+	}
+
+	return f.Name(), nil
 }
 
 func checkReadiness(t *testing.T) (outage time.Duration, status int) {

--- a/proxycore/cluster.go
+++ b/proxycore/cluster.go
@@ -113,6 +113,7 @@ type ClusterInfo struct {
 	Partitioner    string
 	ReleaseVersion string
 	CQLVersion     string
+	LocalDC        string
 }
 
 // Cluster defines a downstream cluster that is being proxied to.
@@ -297,6 +298,7 @@ func (c *Cluster) queryHosts(ctx context.Context, conn *ClientConn, version prim
 	}
 	hosts = c.addHosts(hosts, rs)
 	row := rs.Row(0)
+	localDC := hosts[0].DC
 
 	partitioner, err := row.StringByName("partitioner")
 	if err != nil {
@@ -328,7 +330,7 @@ func (c *Cluster) queryHosts(ctx context.Context, conn *ClientConn, version prim
 		return hosts[i].Key() < hosts[j].Key()
 	})
 
-	return hosts, ClusterInfo{Partitioner: partitioner, ReleaseVersion: releaseVersion, CQLVersion: cqlVersion}, nil
+	return hosts, ClusterInfo{Partitioner: partitioner, ReleaseVersion: releaseVersion, CQLVersion: cqlVersion, LocalDC: localDC}, nil
 }
 
 func (c *Cluster) addHosts(hosts []*Host, rs *ResultSet) []*Host {

--- a/proxycore/host.go
+++ b/proxycore/host.go
@@ -16,10 +16,15 @@ package proxycore
 
 type Host struct {
 	Endpoint
+	DC string
 }
 
 func NewHostFromRow(endpoint Endpoint, row Row) (*Host, error) {
-	return &Host{endpoint}, nil
+	dc, err := row.StringByName("data_center")
+	if err != nil {
+		return nil, err
+	}
+	return &Host{endpoint, dc}, nil
 }
 
 func (h *Host) Key() string {


### PR DESCRIPTION
Multiple proxies can be configured to work together for:
* Multi-region failover in Astra DB.
* ~Bypassing drivers that require at least replication factor number of
  nodes in a cluster for token-aware load balancing.~

Also, added a feature to configure the proxy using a YAML configuration
file. This is necessary for configuring multiple proxies for the `peers`
value. All keys match their CLI counterparts:

```yaml
astra-bundle: path/to/secure-connect-bundle.zip
username: <username>
password: <password>
bind: 127.0.0.1:9042
rpc-address: 127.0.0.1
peers:
  - rpc-address: 127.0.0.1
    data-center: dc-1
  - rpc-address: 127.0.0.2
    data-center: dc-2
```

`peers` is not available via CLI option because it's a complex,
composite value. It's possible to configure everything on the CLI other
than `peers` and put only that in a configuration file.