### PR TITLE
Add `--astra-host` override for cloud private endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Flags:
                                                           ($ASTRA_TOKEN).
   -i, --astra-database-id=STRING                          Database ID of the Astra database. Requires '--astra-token' ($ASTRA_DATABASE_ID)
       --astra-api-url="https://api.astra.datastax.com"    URL for the Astra API ($ASTRA_API_URL)
+      --astra-host=STRING                                 Overrides the Astra DB host. It's useful when using a cloud private endpoint service ($ASTRA_HOST)
+      --astra-timeout=10s                                 Timeout for contacting Astra when retrieving the bundle and metadata ($ASTRA_TIMEOUT)
   -c, --contact-points=CONTACT-POINTS,...                 Contact points for cluster. Ignored if using the bundle path or token option ($CONTACT_POINTS).
   -u, --username=STRING                                   Username to use for authentication ($USERNAME)
   -p, --password=STRING                                   Password to use for authentication ($PASSWORD)

--- a/astra/bundle.go
+++ b/astra/bundle.go
@@ -33,9 +33,9 @@ import (
 )
 
 type Bundle struct {
-	tlsConfig *tls.Config
-	host      string
-	port      int
+	TlsConfig *tls.Config
+	Host      string
+	Port      int
 }
 
 func LoadBundleZip(reader *zip.Reader) (*Bundle, error) {
@@ -69,13 +69,13 @@ func LoadBundleZip(reader *zip.Reader) (*Bundle, error) {
 	}
 
 	return &Bundle{
-		tlsConfig: &tls.Config{
+		TlsConfig: &tls.Config{
 			RootCAs:      rootCAs,
 			Certificates: []tls.Certificate{cert},
 			ServerName:   config.Host,
 		},
-		host: config.Host,
-		port: config.Port,
+		Host: config.Host,
+		Port: config.Port,
 	}, nil
 }
 
@@ -93,7 +93,7 @@ func LoadBundleZipFromPath(path string) (*Bundle, error) {
 }
 
 func LoadBundleZipFromURL(url, databaseID, token string, timeout time.Duration) (*Bundle, error) {
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(timeout))
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	credsURL, err := generateSecureBundleURLWithResponse(url, databaseID, token, ctx)
@@ -152,18 +152,6 @@ func generateSecureBundleURLWithResponse(url, databaseID, token string, ctx cont
 	}
 
 	return res.JSON200, nil
-}
-
-func (b *Bundle) Host() string {
-	return b.host
-}
-
-func (b *Bundle) Port() int {
-	return b.port
-}
-
-func (b *Bundle) TLSConfig() *tls.Config {
-	return b.tlsConfig.Clone()
 }
 
 func extract(reader *zip.Reader) (map[string][]byte, error) {

--- a/astra/bundle_test.go
+++ b/astra/bundle_test.go
@@ -46,8 +46,8 @@ func TestLoadBundleZip(t *testing.T) {
 	b, err := LoadBundleZipFromPath(path)
 	require.NoError(t, err)
 
-	assert.Equal(t, hostname, b.Host())
-	assert.Equal(t, port, b.Port())
+	assert.Equal(t, hostname, b.Host)
+	assert.Equal(t, port, b.Port)
 
 	ca, err := getOrCreateCA()
 	require.NoError(t, err)
@@ -55,13 +55,13 @@ func TestLoadBundleZip(t *testing.T) {
 	// Verify CA added to cert pool
 	caSub, err := asn1.Marshal(ca.cert.Subject.ToRDNSequence())
 	found := false
-	for _, sub := range b.TLSConfig().RootCAs.Subjects() {
+	for _, sub := range b.TlsConfig.RootCAs.Subjects() {
 		if bytes.Compare(caSub, sub) == 0 {
 			found = true
 		}
 	}
 	assert.True(t, found)
-	require.Equal(t, 1, len(b.TLSConfig().Certificates))
+	require.Equal(t, 1, len(b.TlsConfig.Certificates))
 }
 
 func TestLoadBundleZip_InvalidJson(t *testing.T) {

--- a/astra/endpoint.go
+++ b/astra/endpoint.go
@@ -15,12 +15,12 @@
 package astra
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"sync"
 	"time"
@@ -33,6 +33,7 @@ type astraResolver struct {
 	region          string
 	bundle          *Bundle
 	mu              *sync.Mutex
+	timeout         time.Duration
 }
 
 type astraEndpoint struct {
@@ -41,28 +42,38 @@ type astraEndpoint struct {
 	tlsConfig *tls.Config
 }
 
-func NewResolver(bundle *Bundle) proxycore.EndpointResolver {
+func NewResolver(bundle *Bundle, timeout time.Duration) proxycore.EndpointResolver {
 	return &astraResolver{
-		bundle: bundle,
-		mu:     &sync.Mutex{},
+		bundle:  bundle,
+		mu:      &sync.Mutex{},
+		timeout: timeout,
 	}
 }
 
-func (r *astraResolver) Resolve() ([]proxycore.Endpoint, error) {
+func (r *astraResolver) Resolve(ctx context.Context) ([]proxycore.Endpoint, error) {
 	var metadata *astraMetadata
 
-	url := fmt.Sprintf("https://%s:%d/metadata", r.bundle.Host(), r.bundle.Port())
+	ctx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
 	httpsClient := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: r.bundle.TLSConfig(),
+			TLSClientConfig: r.bundle.TlsConfig.Clone(),
 		},
 	}
-	response, err := httpsClient.Get(url)
+
+	url := fmt.Sprintf("https://%s:%d/metadata", r.bundle.Host, r.bundle.Port)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get metadata from %s: %v", url, err)
+		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	response, err := httpsClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get metadata from %s: %w", url, err)
+	}
+
+	body, err := readAllWithTimeout(response.Body, ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +156,7 @@ func (a astraEndpoint) TlsConfig() *tls.Config {
 }
 
 func copyTLSConfig(bundle *Bundle, serverName string) *tls.Config {
-	tlsConfig := bundle.TLSConfig()
+	tlsConfig := bundle.TlsConfig.Clone()
 	tlsConfig.ServerName = serverName
 	tlsConfig.InsecureSkipVerify = true
 	tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
@@ -161,7 +172,7 @@ func copyTLSConfig(bundle *Bundle, serverName string) *tls.Config {
 		opts := x509.VerifyOptions{
 			Roots:         tlsConfig.RootCAs,
 			CurrentTime:   time.Now(),
-			DNSName:       bundle.Host(),
+			DNSName:       bundle.Host,
 			Intermediates: x509.NewCertPool(),
 		}
 		for _, cert := range certs[1:] {

--- a/proxycore/cluster.go
+++ b/proxycore/cluster.go
@@ -150,7 +150,7 @@ func ConnectCluster(ctx context.Context, config ClusterConfig) (*Cluster, error)
 		listeners:        make([]ClusterListener, 0),
 	}
 
-	endpoints, err := config.Resolver.Resolve()
+	endpoints, err := config.Resolver.Resolve(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also, fixes timeouts when contacting Astra services, a custom timeout can be provided using `--astra-timeout`.