### PR TITLE
Fix Astra timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Flags:
                                                           or contact points option ($ASTRA_TOKEN).
   -i, --astra-database-id=STRING                          Database ID of the Astra database. Requires '--astra-token' ($ASTRA_DATABASE_ID)
       --astra-api-url="https://api.astra.datastax.com"    URL for the Astra API ($ASTRA_API_URL)
+      --astra-timeout=10s                                 Timeout for contacting Astra when retrieving the bundle and metadata ($ASTRA_TIMEOUT)
   -c, --contact-points=CONTACT-POINTS,...                 Contact points for cluster. Ignored if using the bundle path or token option ($CONTACT_POINTS).
   -u, --username=STRING                                   Username to use for authentication ($USERNAME)
   -p, --password=STRING                                   Password to use for authentication ($PASSWORD)

--- a/astra/bundle.go
+++ b/astra/bundle.go
@@ -33,7 +33,7 @@ import (
 )
 
 type Bundle struct {
-	TlsConfig *tls.Config
+	TLSConfig *tls.Config
 	Host      string
 	Port      int
 }
@@ -69,7 +69,7 @@ func LoadBundleZip(reader *zip.Reader) (*Bundle, error) {
 	}
 
 	return &Bundle{
-		TlsConfig: &tls.Config{
+		TLSConfig: &tls.Config{
 			RootCAs:      rootCAs,
 			Certificates: []tls.Certificate{cert},
 			ServerName:   config.Host,

--- a/astra/bundle.go
+++ b/astra/bundle.go
@@ -33,9 +33,9 @@ import (
 )
 
 type Bundle struct {
-	tlsConfig *tls.Config
-	host      string
-	port      int
+	TlsConfig *tls.Config
+	Host      string
+	Port      int
 }
 
 func LoadBundleZip(reader *zip.Reader) (*Bundle, error) {
@@ -69,13 +69,13 @@ func LoadBundleZip(reader *zip.Reader) (*Bundle, error) {
 	}
 
 	return &Bundle{
-		tlsConfig: &tls.Config{
+		TlsConfig: &tls.Config{
 			RootCAs:      rootCAs,
 			Certificates: []tls.Certificate{cert},
 			ServerName:   config.Host,
 		},
-		host: config.Host,
-		port: config.Port,
+		Host: config.Host,
+		Port: config.Port,
 	}, nil
 }
 
@@ -93,7 +93,7 @@ func LoadBundleZipFromPath(path string) (*Bundle, error) {
 }
 
 func LoadBundleZipFromURL(url, databaseID, token string, timeout time.Duration) (*Bundle, error) {
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(timeout))
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	credsURL, err := generateSecureBundleURLWithResponse(url, databaseID, token, ctx)
@@ -152,18 +152,6 @@ func generateSecureBundleURLWithResponse(url, databaseID, token string, ctx cont
 	}
 
 	return res.JSON200, nil
-}
-
-func (b *Bundle) Host() string {
-	return b.host
-}
-
-func (b *Bundle) Port() int {
-	return b.port
-}
-
-func (b *Bundle) TLSConfig() *tls.Config {
-	return b.tlsConfig.Clone()
 }
 
 func extract(reader *zip.Reader) (map[string][]byte, error) {

--- a/astra/bundle_test.go
+++ b/astra/bundle_test.go
@@ -40,8 +40,8 @@ func TestLoadBundleZip(t *testing.T) {
 	b, err := LoadBundleZipFromPath(path)
 	require.NoError(t, err)
 
-	assert.Equal(t, hostname, b.Host())
-	assert.Equal(t, port, b.Port())
+	assert.Equal(t, hostname, b.Host)
+	assert.Equal(t, port, b.Port)
 
 	block, _ := pem.Decode(testCAPEM)
 	ca, _ := x509.ParseCertificate(block.Bytes)
@@ -49,13 +49,13 @@ func TestLoadBundleZip(t *testing.T) {
 	// Verify CA added to cert pool
 	caSub, err := asn1.Marshal(ca.Subject.ToRDNSequence())
 	found := false
-	for _, sub := range b.TLSConfig().RootCAs.Subjects() {
+	for _, sub := range b.TlsConfig.RootCAs.Subjects() {
 		if bytes.Compare(caSub, sub) == 0 {
 			found = true
 		}
 	}
 	assert.True(t, found)
-	require.Equal(t, 1, len(b.TLSConfig().Certificates))
+	require.Equal(t, 1, len(b.TlsConfig.Certificates))
 }
 
 func TestLoadBundleZip_InvalidJson(t *testing.T) {

--- a/astra/bundle_test.go
+++ b/astra/bundle_test.go
@@ -49,13 +49,13 @@ func TestLoadBundleZip(t *testing.T) {
 	// Verify CA added to cert pool
 	caSub, err := asn1.Marshal(ca.Subject.ToRDNSequence())
 	found := false
-	for _, sub := range b.TlsConfig.RootCAs.Subjects() {
+	for _, sub := range b.TLSConfig.RootCAs.Subjects() {
 		if bytes.Compare(caSub, sub) == 0 {
 			found = true
 		}
 	}
 	assert.True(t, found)
-	require.Equal(t, 1, len(b.TlsConfig.Certificates))
+	require.Equal(t, 1, len(b.TLSConfig.Certificates))
 }
 
 func TestLoadBundleZip_InvalidJson(t *testing.T) {

--- a/astra/endpoint.go
+++ b/astra/endpoint.go
@@ -58,7 +58,7 @@ func (r *astraResolver) Resolve(ctx context.Context) ([]proxycore.Endpoint, erro
 
 	httpsClient := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: r.bundle.TlsConfig.Clone(),
+			TLSClientConfig: r.bundle.TLSConfig.Clone(),
 		},
 	}
 
@@ -156,7 +156,7 @@ func (a astraEndpoint) TLSConfig() *tls.Config {
 }
 
 func copyTLSConfig(bundle *Bundle, serverName string) *tls.Config {
-	tlsConfig := bundle.TlsConfig.Clone()
+	tlsConfig := bundle.TLSConfig.Clone()
 	tlsConfig.ServerName = serverName
 	tlsConfig.InsecureSkipVerify = true
 	tlsConfig.VerifyPeerCertificate = func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {

--- a/proxy/run.go
+++ b/proxy/run.go
@@ -44,6 +44,7 @@ type runConfig struct {
 	AstraToken         string        `yaml:"astra-token" help:"Token used to authenticate to an Astra database. Requires '--astra-database-id'. Ignored if using the bundle path or contact points option." short:"t" env:"ASTRA_TOKEN"`
 	AstraDatabaseID    string        `yaml:"astra-database-id" help:"Database ID of the Astra database. Requires '--astra-token'" short:"i" env:"ASTRA_DATABASE_ID"`
 	AstraApiURL        string        `yaml:"astra-api-url" help:"URL for the Astra API" default:"https://api.astra.datastax.com" env:"ASTRA_API_URL"`
+	AstraTimeout       time.Duration `yaml:"astra-timeout" help:"Timeout for contacting Astra when retrieving the bundle and metadata" default:"10s" env:"ASTRA_TIMEOUT"`
 	ContactPoints      []string      `yaml:"contact-points" help:"Contact points for cluster. Ignored if using the bundle path or token option." short:"c" env:"CONTACT_POINTS"`
 	Username           string        `yaml:"username" help:"Username to use for authentication" short:"u" env:"USERNAME"`
 	Password           string        `yaml:"password" help:"Password to use for authentication" short:"p" env:"PASSWORD"`
@@ -101,19 +102,18 @@ func Run(ctx context.Context, args []string) int {
 	if len(cfg.AstraBundle) > 0 {
 		if bundle, err := astra.LoadBundleZipFromPath(cfg.AstraBundle); err != nil {
 			cliCtx.Errorf("unable to open bundle %s from file: %v", cfg.AstraBundle, err)
-			return 1
 		} else {
-			resolver = astra.NewResolver(bundle)
+			resolver = astra.NewResolver(bundle, cfg.AstraTimeout)
 		}
 	} else if len(cfg.AstraToken) > 0 {
 		if len(cfg.AstraDatabaseID) == 0 {
 			cliCtx.Fatalf("database ID is required when using a token")
 		}
-		bundle, err := astra.LoadBundleZipFromURL(cfg.AstraApiURL, cfg.AstraDatabaseID, cfg.AstraToken, 10*time.Second)
-		if err != nil {
+		if bundle, err := astra.LoadBundleZipFromURL(cfg.AstraApiURL, cfg.AstraDatabaseID, cfg.AstraToken, cfg.AstraTimeout); err != nil {
 			cliCtx.Fatalf("unable to load bundle %s from astra: %v", cfg.AstraBundle, err)
+		} else {
+			resolver = astra.NewResolver(bundle, cfg.AstraTimeout)
 		}
-		resolver = astra.NewResolver(bundle)
 		cfg.Username = "token"
 		cfg.Password = cfg.AstraToken
 	} else if len(cfg.ContactPoints) > 0 {

--- a/proxycore/cluster.go
+++ b/proxycore/cluster.go
@@ -150,7 +150,7 @@ func ConnectCluster(ctx context.Context, config ClusterConfig) (*Cluster, error)
 		listeners:        make([]ClusterListener, 0),
 	}
 
-	endpoints, err := config.Resolver.Resolve()
+	endpoints, err := config.Resolver.Resolve(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/proxycore/endpoint.go
+++ b/proxycore/endpoint.go
@@ -15,6 +15,7 @@
 package proxycore
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -59,7 +60,7 @@ func (e defaultEndpoint) TLSConfig() *tls.Config {
 }
 
 type EndpointResolver interface {
-	Resolve() ([]Endpoint, error)
+	Resolve(ctx context.Context) ([]Endpoint, error)
 	NewEndpoint(row Row) (Endpoint, error)
 }
 
@@ -87,14 +88,15 @@ func NewResolverWithDefaultPort(contactPoints []string, defaultPort int) Endpoin
 	}
 }
 
-func (r *defaultEndpointResolver) Resolve() ([]Endpoint, error) {
+func (r *defaultEndpointResolver) Resolve(ctx context.Context) ([]Endpoint, error) {
 	var endpoints []Endpoint
+	var resolver net.Resolver
 	for _, cp := range r.contactPoints {
 		host, port, err := net.SplitHostPort(cp)
 		if err != nil {
 			host = cp
 		}
-		addrs, err := net.LookupHost(host)
+		addrs, err := resolver.LookupHost(ctx, host)
 		if err != nil {
 			return nil, fmt.Errorf("unable to resolve contact point %s: %v", cp, err)
 		}


### PR DESCRIPTION
This adds `Context` and timeouts to several paths where calls could block when contacting Astra services. The timeout can be changed by providing the `--astra-timeout` flag with a duration.