### PR TITLE
Align bundle path param name; upgrade image version in k8s sample yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Using Kubernetes with `cql-proxy` requires a number of steps:
 
 1. Generate a token following the Astra [instructions](https://docs.datastax.com/en/astra/docs/manage-application-tokens.html#_create_application_token). This step will display your Client ID, Client Secret, and Token; make sure you download the information for the next steps. Store the secure bundle in `/tmp/scb.zip` to match the example below.
 
-2. Create `cql-proxy.yaml`. You'll need to add three sets of information: arguments, volume mounts, and volumes.
+2. Create `cql-proxy.yaml`. You'll need to add three sets of information: arguments, volume mounts, and volumes. A full example can be found [here](k8s/cql-proxy.yml).
 
  - Argument: Modify the local bundle location, username and password, using the client ID and client secret obtained in the last step to the container argument.   
 
@@ -253,9 +253,9 @@ Using Kubernetes with `cql-proxy` requires a number of steps:
 4. Check the configmap that was created. 
 
     ```sh
-    kubectl describe configmap config
+    kubectl describe configmap cql-proxy-configmap
       
-      Name:         config
+      Name:         cql-proxy-configmap
       Namespace:    default
       Labels:       <none>
       Annotations:  <none>

--- a/k8s/cql-proxy.yml
+++ b/k8s/cql-proxy.yml
@@ -15,9 +15,9 @@ spec:
     spec:
       containers:
       - name: cql-proxy
-        image: datastax/cql-proxy:v0.0.2
+        image: datastax/cql-proxy:v0.1.3
         command: ["./cql-proxy"]
-        args: ["--bundle=/tmp/scb.zip","--username=Client ID","--password=Client Secret"]
+        args: ["--astra-bundle=/tmp/scb.zip","--username=Client ID","--password=Client Secret"]
         volumeMounts:
         - name: my-cm-vol
           mountPath: /tmp/


### PR DESCRIPTION
Upgraded to the latest version of the Docker image for the example yaml (which implies using `--astra-bundle` parameter name to pass the secure-connect-bunde).
Also corrected a small inconsistency in the name of the configmap in the README.

(I stumbled upon these while trying to get cql-proxy running in k8s, so I thought I could share my findings by proposing this tiny improvement in the readme.)