### PR TITLE
Added error check for http GET request

### DIFF
--- a/astra/bundle.go
+++ b/astra/bundle.go
@@ -101,6 +101,9 @@ func LoadBundleZipFromURL(url, databaseID, token string, timeout time.Duration) 
 		return nil, fmt.Errorf("error generating secure bundle zip URLs: %v", err)
 	}
 	resp, err := http.Get(credsURL.DownloadURL)
+	if err != nil {
+		return nil, err
+	}
 
 	defer resp.Body.Close()
 


### PR DESCRIPTION
In case `http.Get` request fails, `resp` will be nil, and this `defer resp.Body.Close()` will cause `panic: runtime error: invalid memory address or nil pointer dereference.`

This PR is related to #109 