### PR TITLE
Add support for AstraAuthenticator

### DIFF
--- a/proxycore/auth.go
+++ b/proxycore/auth.go
@@ -17,10 +17,12 @@ package proxycore
 import (
 	"bytes"
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
 type Authenticator interface {
-	InitialResponse(authenticator string) ([]byte, error)
+	InitialResponse(authenticator string, c *ClientConn) ([]byte, error)
 	EvaluateChallenge(token []byte) ([]byte, error)
 	Success(token []byte) error
 }
@@ -35,14 +37,17 @@ const dseAuthenticator = "com.datastax.bdp.cassandra.auth.DseAuthenticator"
 const passwordAuthenticator = "org.apache.cassandra.auth.PasswordAuthenticator"
 const astraAuthenticator = "org.apache.cassandra.auth.AstraAuthenticator"
 
-func (d *passwordAuth) InitialResponse(authenticator string) ([]byte, error) {
-	switch authenticator {
-	case dseAuthenticator:
+func (d *passwordAuth) InitialResponse(authenticator string, c *ClientConn) ([]byte, error) {
+	if authenticator == dseAuthenticator {
 		return []byte("PLAIN"), nil
-	case passwordAuthenticator, astraAuthenticator:
-		return d.makeToken(), nil
 	}
-	return nil, fmt.Errorf("unknown authenticator: %v", authenticator)
+	// We'll return a SASL response but if we're seeing an authenticator we're unfamiliar with at least log
+	// that information here
+	if (authenticator != passwordAuthenticator) && (authenticator != astraAuthenticator) {
+		c.logger.Info("observed unknown authenticator, treating as SASL",
+			zap.String("authenticator", authenticator))
+	}
+	return d.makeToken(), nil
 }
 
 func (d *passwordAuth) EvaluateChallenge(token []byte) ([]byte, error) {

--- a/proxycore/auth.go
+++ b/proxycore/auth.go
@@ -31,11 +31,15 @@ type passwordAuth struct {
 	password string
 }
 
+const dseAuthenticator = "com.datastax.bdp.cassandra.auth.DseAuthenticator"
+const passwordAuthenticator = "org.apache.cassandra.auth.PasswordAuthenticator"
+const astraAuthenticator = "org.apache.cassandra.auth.AstraAuthenticator"
+
 func (d *passwordAuth) InitialResponse(authenticator string) ([]byte, error) {
 	switch authenticator {
-	case "com.datastax.bdp.cassandra.auth.DseAuthenticator":
+	case dseAuthenticator:
 		return []byte("PLAIN"), nil
-	case "org.apache.cassandra.auth.PasswordAuthenticator":
+	case passwordAuthenticator, astraAuthenticator:
 		return d.makeToken(), nil
 	}
 	return nil, fmt.Errorf("unknown authenticator: %v", authenticator)

--- a/proxycore/clientconn.go
+++ b/proxycore/clientconn.go
@@ -152,7 +152,7 @@ func (c *ClientConn) registerForEvents(ctx context.Context, version primitive.Pr
 }
 
 func (c *ClientConn) authInitialResponse(ctx context.Context, version primitive.ProtocolVersion, auth Authenticator, authenticate *message.Authenticate) error {
-	token, err := auth.InitialResponse(authenticate.Authenticator)
+	token, err := auth.InitialResponse(authenticate.Authenticator, c)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
AstraAuthenticator appears to be used in AD4D (DSE feature support on Astra).  To confirm that that following test sequence was performed:

1. cql-proxy (built from main) against a stock Astra serverless instance:

```
$ ./cql-proxy --astra-bundle 'astra-scb.zip' --username 'token' --password 'myastratoken'
{"level":"info","ts":1705706131.924702,"caller":"proxycore/cluster.go:263","msg":"adding host to the cluster","host":"f7db89d0-f403-4f89-b763-3f0f5679d0f1-us-east-1.db.astra-dev.datastax.com:30047:26fe35c3-ff99-4181-8957-24b32bad1f93"}
...

cqlsh> select * from system.local;

 key   | rpc_address | data_center | rack  | tokens                   | release_version | partitioner                                 | cluster_name | cql_version | schema_version                       | native_protocol_version | host_id
-------+-------------+-------------+-------+--------------------------+-----------------+---------------------------------------------+--------------+-------------+--------------------------------------+-------------------------+--------------------------------------
 local |   127.0.0.1 |   us-east-2 | rack1 | {'-9223372036854775808'} |      4.0.0.6816 | org.apache.cassandra.dht.Murmur3Partitioner |    cql-proxy |       3.4.5 | 4f2b29e6-59b5-4e2d-8fd6-01e32e67f0d7 |   ProtocolVersion OSS 4 | f528764d-624d-3129-b32c-21fbca0cb8d6

(1 rows)
```

2. Same cql-proxy instance (again, built from main) against AD4D instance:

```
$ ./cql-proxy --astra-bundle 'ad4d-scb.zip' --username 'token' --password 'myastratoken'
cql-proxy: error: unable to connect to cluster unknown authenticator: org.apache.cassandra.auth.AstraAuthenticator
```

3. Switch to feature branch, rebuild and test against same AD4D instance:

```
$ go clean
$ go build
$ ./cql-proxy --astra-bundle 'ad4d-scb.zip' --username 'token' --password 'myastratoken'
{"level":"info","ts":1705706131.924702,"caller":"proxycore/cluster.go:263","msg":"adding host to the cluster","host":"f7db89d0-f403-4f89-b763-3f0f5679d0f1-us-east-1.db.astra-dev.datastax.com:30047:26fe35c3-ff99-4181-8957-24b32bad1f93"}
...

cqlsh> select * from system.local;

 key   | rpc_address | data_center | dse_version | rack  | tokens                   | release_version | partitioner                                 | cluster_name | cql_version | schema_version                       | native_protocol_version | host_id
-------+-------------+-------------+-------------+-------+--------------------------+-----------------+---------------------------------------------+--------------+-------------+--------------------------------------+-------------------------+--------------------------------------
 local |   127.0.0.1 |        dc-1 |   6.8.33.47 | rack1 | {'-9223372036854775808'} |      4.0.0.6833 | org.apache.cassandra.dht.Murmur3Partitioner |    cql-proxy |       3.4.5 | 4f2b29e6-59b5-4e2d-8fd6-01e32e67f0d7 |   ProtocolVersion OSS 4 | f528764d-624d-3129-b32c-21fbca0cb8d6

(1 rows)
```