### PR TITLE
Fix connection leak of session with dropped keyspace

### DIFF
--- a/proxycore/connpool.go
+++ b/proxycore/connpool.go
@@ -153,17 +153,17 @@ func (p *connPool) connect() (conn *ClientConn, err error) {
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, fmt.Errorf("handshake took longer than %s to complete", p.config.ConnectTimeout)
 		}
-		return nil, err
+		return conn, err
 	}
 	if version != p.config.Version {
 		p.logger.Error("protocol version not support", zap.Stringer("wanted", p.config.Version), zap.Stringer("got", version))
-		return nil, ProtocolNotSupported
+		return conn, ProtocolNotSupported
 	}
 
 	if len(p.config.Keyspace) != 0 {
 		err = conn.SetKeyspace(ctx, p.config.Version, p.config.Keyspace)
 		if err != nil {
-			return nil, err
+			return conn, err
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the connection leak problem of reconnection failure.

When a keyspace is dropped and the origin server is restarted, cql-proxy attempts to reconnect. However, the new connection fails to set the keyspace, leading to a memory leak each time cql-proxy tries to connect to the server.

```
2024-06-29T17:23:48.232+0900	INFO	proxycore/connpool.go:193	pool connection attempting to reconnect after delay	{"host": "127.0.0.1:9042", "delay": "10s"}
```

The root cause of this issue is that the connection cleanup process is not functioning as expected.
Specifically, the `conn` variable is always nil because the statement `return nil, err` overwrites the `conn` variable.