### PR TITLE
Add support for "select now() from system.local"

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -17,7 +17,11 @@ package parser
 import (
 	"testing"
 
+	"github.com/datastax/go-cassandra-native-protocol/datacodec"
+	"github.com/datastax/go-cassandra-native-protocol/primitive"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParser(t *testing.T) {
@@ -35,56 +39,56 @@ func TestParser(t *testing.T) {
 			Selectors: []Selector{
 				&IDSelector{Name: "key"},
 				&AliasSelector{Alias: "address", Selector: &IDSelector{Name: "rpc_address"}},
-				&CountStarSelector{Name: "count(*)"},
+				&CountFuncSelector{Arg: "*"},
 			},
 		}, false},
 		{"system", "SELECT count(*) FROM local", true, true, &SelectStatement{
 			Keyspace: "system",
 			Table:    "local",
 			Selectors: []Selector{
-				&CountStarSelector{Name: "count(*)"},
+				&CountFuncSelector{Arg: "*"},
 			},
 		}, false},
 		{"system", "SELECT count(*) FROM \"local\"", true, true, &SelectStatement{
 			Keyspace: "system",
 			Table:    "local",
 			Selectors: []Selector{
-				&CountStarSelector{Name: "count(*)"},
+				&CountFuncSelector{Arg: "*"},
 			},
 		}, false},
 		{"", "SELECT count(*) FROM system.peers", true, true, &SelectStatement{
 			Keyspace: "system",
 			Table:    "peers",
 			Selectors: []Selector{
-				&CountStarSelector{Name: "count(*)"},
+				&CountFuncSelector{Arg: "*"},
 			},
 		}, false},
 		{"", "SELECT count(*) FROM \"system\".\"peers\"", true, true, &SelectStatement{
 			Keyspace: "system",
 			Table:    "peers",
 			Selectors: []Selector{
-				&CountStarSelector{Name: "count(*)"},
+				&CountFuncSelector{Arg: "*"},
 			},
 		}, false},
 		{"system", "SELECT count(*) FROM peers", true, true, &SelectStatement{
 			Keyspace: "system",
 			Table:    "peers",
 			Selectors: []Selector{
-				&CountStarSelector{Name: "count(*)"},
+				&CountFuncSelector{Arg: "*"},
 			},
 		}, false},
 		{"", "SELECT count(*) FROM system.peers_v2", true, true, &SelectStatement{
 			Keyspace: "system",
 			Table:    "peers_v2",
 			Selectors: []Selector{
-				&CountStarSelector{Name: "count(*)"},
+				&CountFuncSelector{Arg: "*"},
 			},
 		}, false},
 		{"system", "SELECT count(*) FROM peers_v2", true, true, &SelectStatement{
 			Keyspace: "system",
 			Table:    "peers_v2",
 			Selectors: []Selector{
-				&CountStarSelector{Name: "count(*)"},
+				&CountFuncSelector{Arg: "*"},
 			},
 		}, false},
 		{"", "SELECT func(key) FROM system.local", true, true, nil, true},
@@ -174,5 +178,59 @@ func TestParser(t *testing.T) {
 		assert.Equal(t, tt.handled, handled, "invalid handled", tt.query)
 		assert.Equal(t, tt.idempotent, idempotent, "invalid idempotency", tt.query)
 		assert.Equal(t, tt.stmt, stmt, "invalid parsed statement", tt.query)
+	}
+}
+
+func TestParserSystemNowFunction(t *testing.T) {
+	var tests = []struct {
+		query string
+		table string
+	}{
+		{"SELECT now() FROM system.local", "local"},
+		{"SELECT now() FROM system.peers", "peers"},
+	}
+
+	start, _, err := uuid.GetTime()
+	require.NoError(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			handled, stmt, err := IsQueryHandled(IdentifierFromString(""), tt.query)
+			assert.NoError(t, err, tt.query)
+			assert.True(t, handled, tt.query)
+			require.NotNil(t, stmt)
+			if selectStmt, ok := stmt.(*SelectStatement); ok {
+				require.Len(t, selectStmt.Selectors, 1)
+				selector := selectStmt.Selectors[0]
+				require.NotNil(t, selector)
+				if nowSelector, ok := selector.(*NowFuncSelector); ok {
+					values, err := nowSelector.Values(nil, nil)
+					assert.NoError(t, err)
+					assert.Len(t, values, 1)
+
+					var u primitive.UUID
+					wasNull, err := datacodec.Timeuuid.Decode(values[0], &u, primitive.ProtocolVersion4)
+					assert.False(t, wasNull)
+					assert.NoError(t, err)
+
+					v, err := uuid.FromBytes(u[:])
+					assert.NoError(t, err)
+					assert.Equal(t, uuid.RFC4122, v.Variant())
+					assert.Equal(t, uuid.Version(1), v.Version())
+					assert.GreaterOrEqual(t, v.Time(), start)
+
+					columns, err := nowSelector.Columns(nil, selectStmt)
+					assert.NoError(t, err)
+					assert.Len(t, columns, 1)
+					assert.Equal(t, "system.now()", columns[0].Name)
+					assert.Equal(t, "system", columns[0].Keyspace)
+					assert.Equal(t, tt.table, columns[0].Table)
+				} else {
+					assert.Fail(t, "expected now function selector")
+				}
+			} else {
+				assert.Fail(t, "expected select statement")
+			}
+		})
 	}
 }

--- a/parser/parser_utils.go
+++ b/parser/parser_utils.go
@@ -44,12 +44,12 @@ func FilterValues(stmt *SelectStatement, columns []*message.ColumnMetadata, valu
 
 func FilterColumns(stmt *SelectStatement, columns []*message.ColumnMetadata) (filtered []*message.ColumnMetadata, err error) {
 	for _, selector := range stmt.Selectors {
-		var columns []*message.ColumnMetadata
-		columns, err = selector.Columns(columns, stmt)
+		var cols []*message.ColumnMetadata
+		cols, err = selector.Columns(columns, stmt)
 		if err != nil {
 			return nil, err
 		}
-		filtered = append(filtered, columns...)
+		filtered = append(filtered, cols...)
 	}
 	return filtered, nil
 }

--- a/parser/parser_utils.go
+++ b/parser/parser_utils.go
@@ -16,9 +16,7 @@ package parser
 
 import (
 	"errors"
-	"fmt"
 
-	"github.com/datastax/go-cassandra-native-protocol/datatype"
 	"github.com/datastax/go-cassandra-native-protocol/message"
 )
 
@@ -33,99 +31,27 @@ var nonIdempotentFuncs = []string{"uuid", "now"}
 type ValueLookupFunc func(name string) (value message.Column, err error)
 
 func FilterValues(stmt *SelectStatement, columns []*message.ColumnMetadata, valueFunc ValueLookupFunc) (filtered []message.Column, err error) {
-	if _, ok := stmt.Selectors[0].(*StarSelector); ok {
-		for _, column := range columns {
-			var val message.Column
-			val, err = valueFunc(column.Name)
-			if err != nil {
-				return nil, err
-			}
-			filtered = append(filtered, val)
-		}
-	} else {
-		for _, selector := range stmt.Selectors {
-			var val message.Column
-			val, err = valueFromSelector(selector, valueFunc)
-			if err != nil {
-				return nil, err
-			}
-			filtered = append(filtered, val)
-		}
-	}
-	return filtered, nil
-}
-
-func valueFromSelector(selector Selector, valueFunc ValueLookupFunc) (val message.Column, err error) {
-	switch s := selector.(type) {
-	case *CountStarSelector:
-		return valueFunc(CountValueName)
-	case *IDSelector:
-		return valueFunc(s.Name)
-	case *AliasSelector:
-		return valueFromSelector(s.Selector, valueFunc)
-	default:
-		return nil, errors.New("unhandled selector type")
-	}
-}
-
-func FilterColumns(stmt *SelectStatement, columns []*message.ColumnMetadata) (filtered []*message.ColumnMetadata, err error) {
-	if _, ok := stmt.Selectors[0].(*StarSelector); ok {
-		filtered = columns
-	} else {
-		for _, selector := range stmt.Selectors {
-			var column *message.ColumnMetadata
-			column, err = columnFromSelector(selector, columns, stmt.Keyspace, stmt.Table)
-			if err != nil {
-				return nil, err
-			}
-			filtered = append(filtered, column)
-		}
-	}
-	return filtered, nil
-}
-
-func isCountSelector(selector Selector) bool {
-	_, ok := selector.(*CountStarSelector)
-	return ok
-}
-
-func IsCountStarQuery(stmt *SelectStatement) bool {
-	if len(stmt.Selectors) == 1 {
-		if isCountSelector(stmt.Selectors[0]) {
-			return true
-		} else if alias, ok := stmt.Selectors[0].(*AliasSelector); ok {
-			return isCountSelector(alias.Selector)
-		}
-	}
-	return false
-}
-
-func columnFromSelector(selector Selector, columns []*message.ColumnMetadata, keyspace string, table string) (column *message.ColumnMetadata, err error) {
-	switch s := selector.(type) {
-	case *CountStarSelector:
-		return &message.ColumnMetadata{
-			Keyspace: keyspace,
-			Table:    table,
-			Name:     s.Name,
-			Type:     datatype.Int,
-		}, nil
-	case *IDSelector:
-		if column = FindColumnMetadata(columns, s.Name); column != nil {
-			return column, nil
-		} else {
-			return nil, fmt.Errorf("invalid column %s", s.Name)
-		}
-	case *AliasSelector:
-		column, err = columnFromSelector(s.Selector, columns, keyspace, table)
+	for _, selector := range stmt.Selectors {
+		var vals []message.Column
+		vals, err = selector.Values(columns, valueFunc)
 		if err != nil {
 			return nil, err
 		}
-		alias := *column // Make a copy so we can modify the name
-		alias.Name = s.Alias
-		return &alias, nil
-	default:
-		return nil, errors.New("unhandled selector type")
+		filtered = append(filtered, vals...)
 	}
+	return filtered, nil
+}
+
+func FilterColumns(stmt *SelectStatement, columns []*message.ColumnMetadata) (filtered []*message.ColumnMetadata, err error) {
+	for _, selector := range stmt.Selectors {
+		var columns []*message.ColumnMetadata
+		columns, err = selector.Columns(columns, stmt)
+		if err != nil {
+			return nil, err
+		}
+		filtered = append(filtered, columns...)
+	}
+	return filtered, nil
 }
 
 func isSystemTable(name Identifier) bool {


### PR DESCRIPTION
Fixes #137, at least the bits about adding support for `select now() from system.local`.  The rest of #137 will be handled in #141.

Note that all code contained in this PR was originally written by @mpenick.