### PR TITLE
Update Go version to 1.24.2

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     name: Build and Upload Release Assets
     runs-on: ubuntu-latest
-    container: golang:1.18-bullseye
+    container: golang:1.24.2-bullseye
     strategy:
       matrix:
         goosarch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.24.2]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as builder
+FROM golang:1.24.2 as builder
 
 # Disable cgo to remove gcc dependency
 ENV CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datastax/cql-proxy
 
-go 1.18
+go 1.24.2
 
 require (
 	github.com/alecthomas/kong v0.2.17


### PR DESCRIPTION
Aim is to address [CVE-2025-22871](https://github.com/advisories/GHSA-g9pc-8g42-g6vq)