### PR TITLE
Mark checkout dir as a "safe" git dir in order to enable VCS stamping.

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -33,9 +33,12 @@ jobs:
           export GOOSARCH=${{ matrix.goosarch }}
           export GOOS=${GOOSARCH%/*}
           export GOARCH=${GOOSARCH#*/}
-          
+
           mkdir -p artifacts
-          
+
+          # Issue 152.  Explicitly mark the checked-out directory as a safe git dir to enable VCS stamping
+          git config --global --add safe.directory /__w/cql-proxy/cql-proxy
+
           if [ "$GOOS" = "windows" ]; then
             go build -o cql-proxy.exe
             zip -vr cql-proxy-${GOOS}-${GOARCH}-${{ github.ref_name }}.zip cql-proxy.exe LICENSE


### PR DESCRIPTION
This approach was used to get to a workable cql-proxy 0.2.0 native build with go 1.24.2